### PR TITLE
Fix cross-sheet cell property access via delegate bridge

### DIFF
--- a/formula-boss.Tests/InterceptionTests.cs
+++ b/formula-boss.Tests/InterceptionTests.cs
@@ -272,7 +272,7 @@ public class InterceptionTests
     {
         public int CompileCount { get; private set; }
 
-        public override List<string> CompileAndRegister(string source)
+        public override List<string> CompileAndRegister(string source, bool isMacroType = false)
         {
             CompileCount++;
             // Return empty list (success) without actually compiling

--- a/formula-boss.Tests/TranspilerTests.cs
+++ b/formula-boss.Tests/TranspilerTests.cs
@@ -421,15 +421,14 @@ public class TranspilerTests
     }
 
     [Fact]
-    public void Transpiler_ObjectModel_UsesInlineReflection()
+    public void Transpiler_ObjectModel_UsesRuntimeHelpers()
     {
         var result = Transpile("data.cells.toArray()");
 
-        // Object model path uses inline reflection for ExcelReference → Range conversion
-        Assert.Contains("ExcelDnaUtil", result.SourceCode);
-        // Uses property-based address building instead of XlCall
-        Assert.Contains("RowFirst", result.SourceCode);
-        Assert.Contains("ColumnFirst", result.SourceCode);
+        // Object model path finds RuntimeHelpers via reflection on the host assembly
+        // and invokes GetRangeFromReference to get a sheet-qualified COM Range
+        Assert.Contains("GetRangeFromReference", result.SourceCode);
+        Assert.Contains("formula-boss", result.SourceCode);
         Assert.Contains("dynamic range", result.SourceCode);
     }
 

--- a/formula-boss/AddIn.cs
+++ b/formula-boss/AddIn.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 using ExcelDna.Integration;
 
@@ -21,6 +21,16 @@ public sealed class AddIn : IExcelAddIn, IDisposable
     {
         try
         {
+            // Initialize the range resolver delegate for cross-sheet object model access.
+            // Must be done here (host assembly context) so the lambda can call XlCall directly.
+            RuntimeHelpers.ResolveRangeDelegate = rangeRef =>
+            {
+                var address = (string)XlCall.Excel(XlCall.xlfReftext, rangeRef, true);
+                Debug.WriteLine($"ResolveRangeDelegate: {address}");
+                dynamic app = ExcelDnaUtil.Application;
+                return app.Range[address];
+            };
+
             // Defer event hookup until Excel is fully initialized
             // ExcelAsyncUtil.QueueAsMacro ensures we run after AutoOpen completes
             ExcelAsyncUtil.QueueAsMacro(InitializeInterception);

--- a/formula-boss/Interception/FormulaPipeline.cs
+++ b/formula-boss/Interception/FormulaPipeline.cs
@@ -132,7 +132,7 @@ public class FormulaPipeline
         Debug.WriteLine("=== End Generated Code ===");
 
         // Step 4: Compile and Register
-        var compileErrors = _compiler.CompileAndRegister(transpileResult.SourceCode);
+        var compileErrors = _compiler.CompileAndRegister(transpileResult.SourceCode, transpileResult.RequiresObjectModel);
 
         if (compileErrors.Count > 0)
         {


### PR DESCRIPTION
## Summary

- **Cross-sheet cell property fix**: Object model UDFs (`.cells`, `.color`, `.bold`) now correctly resolve ranges across sheets using `xlfReftext` for sheet-qualified addresses, via a delegate bridge pattern that works around ExcelDNA assembly identity constraints
- **IsMacroType registration**: Object model UDFs are registered with `IsMacroType = true` (required for `xlfReftext` C API access)
- **Documentation**: Added delegate bridge pattern and transitive assembly identity rules to CLAUDE.md; documented full root cause and resolution in `docs/cross-sheet-cell-properties.md`

## Key design decision

Generated (Roslyn-compiled) code cannot load host types that reference ExcelDNA (transitive `TypeLoadException`), and reflection-based `XlCall.Excel` doesn't work for C API functions. The solution uses a `Func<object, object>` delegate on `RuntimeHelpers` (zero ExcelDNA dependencies), initialized from `AddIn.AutoOpen` with a lambda that calls `XlCall` directly in the host context.

## Test plan

- [x] Verify object model UDFs return correct values for same-sheet references
- [x] Verify object model UDFs return correct values for cross-sheet references
- [x] Verify pressing F9 from any sheet produces correct results on all sheets
- [x] Verify value-only UDFs (`.values`) are unaffected
- [x] All 326 unit/integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)