### PR TITLE
Fix UDF names colliding with reserved Excel/XLM names

### DIFF
--- a/formula-boss.Tests/TranspilerTests.cs
+++ b/formula-boss.Tests/TranspilerTests.cs
@@ -191,6 +191,20 @@ public class TranspilerTests
         Assert.StartsWith("__udf_", result.MethodName);
     }
 
+    [Theory]
+    [InlineData("result", "_RESULT")]
+    [InlineData("RESULT", "_RESULT")]
+    [InlineData("sum", "_SUM")]
+    [InlineData("filter", "_FILTER")]
+    [InlineData("index", "_INDEX")]
+    [InlineData("let", "_LET")]
+    public void Transpiler_PrefixesReservedExcelNames(string preferredName, string expectedName)
+    {
+        var result = TranspileWithName("data.values.toArray()", preferredName);
+
+        Assert.Equal(expectedName, result.MethodName);
+    }
+
     #endregion
 
     #region Code Generation - Literals

--- a/formula-boss/Interception/FormulaPipeline.cs
+++ b/formula-boss/Interception/FormulaPipeline.cs
@@ -232,6 +232,12 @@ public class FormulaPipeline
             str = "_" + str;
         }
 
+        // Must match CSharpTranspiler.SanitizeUdfName reserved name handling
+        if (CSharpTranspiler.IsReservedExcelName(str))
+        {
+            str = "_" + str;
+        }
+
         return str;
     }
 


### PR DESCRIPTION
## Summary

- `RESULT`, `SUM`, `FILTER`, and other reserved Excel/XLM function names are now prefixed with `_` when used as UDF names (e.g. `RESULT` → `_RESULT`)
- Fixes the `0x800A03EC` error when a LET variable name like `result` produces a UDF name that collides with Excel's XLM namespace
- Both `CSharpTranspiler.SanitizeUdfName` and `FormulaPipeline.SanitizeName` updated to stay in sync

## Test plan

- [x] 6 new parameterized tests for reserved name prefixing (`result`, `sum`, `filter`, `index`, `let`)
- [x] All 332 existing tests pass
- [x] Manual: enter `=LET(result, \`tblShop.rows.select(r => { return r.Name; })\`, result)` — should succeed instead of showing 0x800A03EC

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)