### PR TITLE
Use global CLAUDE.md for issue conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,7 @@ Detailed specifications and implementation plans:
 This repo follows the [Taglo Claude Code workflow](https://github.com/TagloGit/taglo-pm/blob/main/docs/claude-code-workflow.md).
 
 ### GitHub Issues
-- Labels: `status: backlog`, `status: in-progress`, `status: in-review`, `status: done`, `blocked: tim`
-- Type labels: `bug`, `enhancement`, `documentation`, `refactor`, `process`
-- PRs must include `Closes #N`
+- See global `~/.claude/CLAUDE.md` for full label schema, status transitions, and issue conventions.
 
 ### Available Skills and Agents
 - `/developer <issue>` — Execute implementation work


### PR DESCRIPTION
## Summary
- Replace inline GitHub Issues label/convention docs with a reference to the global `~/.claude/CLAUDE.md`
- Keeps conventions in sync across all Taglo repos from a single source

## Test plan
- [x] Verify Claude Code sessions in this repo pick up the global file

🤖 Generated with [Claude Code](https://claude.com/claude-code)