### PR TITLE
Add configurable IndentSize and AvalonEdit test reference (#36)

### DIFF
--- a/formula-boss.Tests/formula-boss.Tests.csproj
+++ b/formula-boss.Tests/formula-boss.Tests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AvalonEdit" Version="6.*" />
     <PackageReference Include="ExcelDna.Integration" Version="1.*">
       <PrivateAssets>none</PrivateAssets>
     </PackageReference>

--- a/formula-boss/UI/EditorSettings.cs
+++ b/formula-boss/UI/EditorSettings.cs
@@ -8,6 +8,7 @@ public class EditorSettings
 
     public double Width { get; set; } = 500;
     public double Height { get; set; } = 300;
+    public int IndentSize { get; set; } = 2;
 
     private static string SettingsDirectory =>
         Path.Combine(

--- a/formula-boss/UI/FloatingEditorWindow.xaml.cs
+++ b/formula-boss/UI/FloatingEditorWindow.xaml.cs
@@ -36,7 +36,7 @@ public partial class FloatingEditorWindow
         LoadSyntaxHighlighting();
 
         // Enable auto-indentation
-        FormulaEditor.Options.IndentationSize = 4;
+        FormulaEditor.Options.IndentationSize = _settings.IndentSize;
         FormulaEditor.Options.ConvertTabsToSpaces = true;
         FormulaEditor.TextArea.IndentationStrategy =
             new CSharpIndentationStrategy(FormulaEditor.Options);


### PR DESCRIPTION
## Summary
- Add `IndentSize` property to `EditorSettings` (default: 2)
- Wire `_settings.IndentSize` into `FloatingEditorWindow` replacing hardcoded `4`
- Add AvalonEdit package reference to test project

Closes #36

## Test plan
- [x] Build passes (0 errors)
- [x] All 370 tests pass
- [x] Tim: open editor, verify indent is 2 spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)