### PR TITLE
Add Cut/Copy empty selection as whole line (B9)

### DIFF
--- a/formula-boss.Tests/EditorBehaviorHandlerTests.cs
+++ b/formula-boss.Tests/EditorBehaviorHandlerTests.cs
@@ -814,4 +814,65 @@ public class EditorBehaviorHandlerTests
             Assert.False(handler.TrySurroundSelection('a'));
         });
     }
+
+    public class CutWholeLine : EditorBehaviorHandlerTests
+    {
+        [Fact]
+        public void Cuts_current_line_including_newline() => RunOnSta(() =>
+        {
+            string? clipped = null;
+            var (editor, handler) = CreateEditor("aaa\nbbb\nccc", 5);
+            handler.SetClipboardText = t => clipped = t;
+            handler.CutWholeLine();
+            Assert.Equal("aaa\nccc", editor.Text);
+            Assert.Equal("bbb\n", clipped);
+        });
+
+        [Fact]
+        public void Cuts_last_line_without_trailing_newline() => RunOnSta(() =>
+        {
+            string? clipped = null;
+            var (editor, handler) = CreateEditor("aaa\nbbb", 5);
+            handler.SetClipboardText = t => clipped = t;
+            handler.CutWholeLine();
+            Assert.Equal("aaa\n", editor.Text);
+            Assert.Equal("bbb", clipped);
+        });
+
+        [Fact]
+        public void Cuts_single_line_document() => RunOnSta(() =>
+        {
+            string? clipped = null;
+            var (editor, handler) = CreateEditor("hello", 2);
+            handler.SetClipboardText = t => clipped = t;
+            handler.CutWholeLine();
+            Assert.Equal("", editor.Text);
+            Assert.Equal("hello", clipped);
+        });
+    }
+
+    public class CopyWholeLine : EditorBehaviorHandlerTests
+    {
+        [Fact]
+        public void Copies_current_line_including_newline() => RunOnSta(() =>
+        {
+            string? clipped = null;
+            var (editor, handler) = CreateEditor("aaa\nbbb\nccc", 5);
+            handler.SetClipboardText = t => clipped = t;
+            handler.CopyWholeLine();
+            Assert.Equal("aaa\nbbb\nccc", editor.Text);
+            Assert.Equal("bbb\n", clipped);
+        });
+
+        [Fact]
+        public void Copies_last_line_without_trailing_newline() => RunOnSta(() =>
+        {
+            string? clipped = null;
+            var (editor, handler) = CreateEditor("aaa\nbbb", 5);
+            handler.SetClipboardText = t => clipped = t;
+            handler.CopyWholeLine();
+            Assert.Equal("aaa\nbbb", editor.Text);
+            Assert.Equal("bbb", clipped);
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- **Ctrl+X with no selection** cuts the entire current line (including newline) to clipboard
- **Ctrl+C with no selection** copies the entire current line to clipboard
- Matches VS/VS Code behavior

Closes #42

## Test plan
- [x] Unit tests for cut: middle line, last line, single-line document
- [x] Unit tests for copy: middle line, last line
- [x] Full test suite passes (464 tests)
- [x] Manual test in Excel with floating editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)