### PR TITLE
Validate LET variable column access and catch formula write errors

### DIFF
--- a/formula-boss.AddinTests/PipelineTests.cs
+++ b/formula-boss.AddinTests/PipelineTests.cs
@@ -756,4 +756,63 @@ public class PipelineTests
             TestUtilities.CleanupWorksheet(ws);
         }
     }
+
+    [Fact]
+    public void LetFormula_ColumnAccessOnLetVariable_ShowsError()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            // Set up a table
+            TestUtilities.SetCellValue(ws, "A1", "Name");
+            TestUtilities.SetCellValue(ws, "B1", "Amount");
+            TestUtilities.SetCellValue(ws, "A2", "Alice");
+            TestUtilities.SetCellValue(ws, "B2", 100.0);
+            TestUtilities.SetCellValue(ws, "A3", "Bob");
+            TestUtilities.SetCellValue(ws, "B3", 200.0);
+
+            var range = ws.Range["A1:B3"];
+            var tables = ws.ListObjects;
+            try
+            {
+                var table = tables.Add(1, range, Type.Missing, 1);
+                try
+                {
+                    var tableName = (string)table.Name;
+
+                    // LET formula where backtick expression uses column access on a LET variable
+                    TestUtilities.EnterBacktickFormula(ws, "D1",
+                        $"=LET(sales, {tableName}, `sales.Rows.Where(r => (double)r[\"Amount\"] > 150).Count()`)");
+
+                    Thread.Sleep(5000);
+
+                    var formula = TestUtilities.GetCellFormula(ws, "D1");
+                    var comment = TestUtilities.GetCellComment(ws, "D1");
+
+                    _output.WriteLine($"D1 formula: {formula}");
+                    _output.WriteLine($"D1 comment: {comment}");
+
+                    // Should show error about LET variable column access, not a COM exception
+                    Assert.NotNull(comment);
+                    Assert.Contains("LET variable", comment);
+                    Assert.Contains("sales", comment);
+                    // Formula should be left as backtick text (not rewritten)
+                    Assert.True(formula?.Contains('`') ?? false, "Formula should not have been rewritten");
+                }
+                finally
+                {
+                    System.Runtime.InteropServices.Marshal.ReleaseComObject(table);
+                }
+            }
+            finally
+            {
+                System.Runtime.InteropServices.Marshal.ReleaseComObject(tables);
+                System.Runtime.InteropServices.Marshal.ReleaseComObject(range);
+            }
+        }
+        finally
+        {
+            TestUtilities.CleanupWorksheet(ws);
+        }
+    }
 }

--- a/formula-boss.Runtime.Tests/CellEscalationTests.cs
+++ b/formula-boss.Runtime.Tests/CellEscalationTests.cs
@@ -1,4 +1,4 @@
-using Xunit;
+﻿using Xunit;
 
 namespace FormulaBoss.Runtime.Tests;
 
@@ -15,15 +15,12 @@ public class CellEscalationTests : IDisposable
             Address = $"${(char)('A' + col - 1)}${row}",
             Row = row,
             Col = col,
-            Interior = new Interior(row % 8, row * 1000 + col),
+            Interior = new Interior(row % 8, (row * 1000) + col),
             Font = new CellFont(row % 2 == 0, col % 2 == 0, 11.0, "Calibri", 0)
         };
     }
 
-    public void Dispose()
-    {
-        RuntimeBridge.GetCell = null;
-    }
+    public void Dispose() => RuntimeBridge.GetCell = null;
 
     [Fact]
     public void ColumnValue_Cell_EscalatesToCom()

--- a/formula-boss.Runtime.Tests/CellExtensionsTests.cs
+++ b/formula-boss.Runtime.Tests/CellExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Xunit;
+﻿using Xunit;
 
 namespace FormulaBoss.Runtime.Tests;
 
@@ -10,13 +10,13 @@ public class CellExtensionsTests
         Interior = new Interior(color, 0)
     };
 
-    private static List<Cell> TestCells() => new()
-    {
-        MakeCell(10, color: 3),
-        MakeCell(20, color: 6),
-        MakeCell(30, color: 3),
-        MakeCell(40, color: 6)
-    };
+    private static List<Cell> TestCells() =>
+    [
+        MakeCell(10, 3),
+        MakeCell(20, 6),
+        MakeCell(30, 3),
+        MakeCell(40, 6)
+    ];
 
     [Fact]
     public void Sum_AllCells() =>

--- a/formula-boss.Runtime.Tests/ResultConverterTests.cs
+++ b/formula-boss.Runtime.Tests/ResultConverterTests.cs
@@ -83,10 +83,7 @@ public class ResultConverterTests
     public void Convert_EnumerableRow_ReturnsObjectArray()
     {
         var columnMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { { "A", 0 }, { "B", 1 } };
-        IEnumerable<Row> rows = new[]
-        {
-            new Row(new object?[] { 1.0, "X" }, columnMap), new Row(new object?[] { 2.0, "Y" }, columnMap)
-        };
+        IEnumerable<Row> rows = new[] { new Row([1.0, "X"], columnMap), new Row([2.0, "Y"], columnMap) };
 
         var result = ResultConverter.Convert(rows);
         var arr = Assert.IsType<object?[,]>(result);
@@ -112,7 +109,7 @@ public class ResultConverterTests
     [Fact]
     public void Convert_RowResult_SpillsAsSingleRow()
     {
-        var row = new Row(new object?[] { "Alice", 30.0 }, null);
+        var row = new Row(["Alice", 30.0], null);
         ExcelValue rowAsExcel = row; // implicit conversion to ExcelArray 1×2
         var result = ResultConverter.Convert(rowAsExcel);
         var arr = Assert.IsType<object?[,]>(result);

--- a/formula-boss/Interception/FormulaInterceptor.cs
+++ b/formula-boss/Interception/FormulaInterceptor.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 using ExcelDna.Integration;
 
@@ -143,7 +143,8 @@ public class FormulaInterceptor : IDisposable
 
             // Check if this is a LET formula - handle specially for named UDFs
             if (LetFormulaParser.TryParse(originalFormula, out var letStructure) &&
-                letStructure!.Bindings.Any(b => b.HasBacktick))
+                (letStructure!.Bindings.Any(b => b.HasBacktick) ||
+                 letStructure.ResultExpression.Contains('`')))
             {
                 ProcessLetFormula(cell, letStructure);
                 return;
@@ -234,6 +235,51 @@ public class FormulaInterceptor : IDisposable
             }
         }
 
+        // Validate: column access on LET variables is not supported
+        var letVariableNames = new HashSet<string>(
+            letStructure.Bindings
+                .Where(b => !b.HasBacktick)
+                .Select(b => b.VariableName.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (_, processed) in processedBindings)
+        {
+            foreach (var param in processed.Parameters)
+            {
+                if (!param.EndsWith("[#All]"))
+                {
+                    continue;
+                }
+
+                var baseName = param[..^"[#All]".Length];
+                if (letVariableNames.Contains(baseName))
+                {
+                    errors.Add(
+                        $"Column access (r[\"..\"]) requires a direct table reference. " +
+                        $"LET variable '{baseName}' cannot be used — use the table name directly.");
+                }
+            }
+        }
+
+        if (processedResult != null)
+        {
+            foreach (var param in processedResult.Parameters)
+            {
+                if (!param.EndsWith("[#All]"))
+                {
+                    continue;
+                }
+
+                var baseName = param[..^"[#All]".Length];
+                if (letVariableNames.Contains(baseName))
+                {
+                    errors.Add(
+                        $"Column access (r[\"..\"]) requires a direct table reference. " +
+                        $"LET variable '{baseName}' cannot be used — use the table name directly.");
+                }
+            }
+        }
+
         if (errors.Count > 0)
         {
             SetCellError(cell, string.Join("\n", errors));
@@ -243,8 +289,7 @@ public class FormulaInterceptor : IDisposable
         var newFormula = LetFormulaRewriter.Rewrite(letStructure, processedBindings, processedResult);
         Debug.WriteLine($"Rewriting LET formula to: {newFormula}");
 
-        cell.Formula2 = newFormula;
-        ClearCellComment(cell);
+        WriteFormula(cell, newFormula);
     }
 
     private void ProcessBacktickFormula(dynamic cell, string originalFormula)
@@ -289,8 +334,21 @@ public class FormulaInterceptor : IDisposable
         var newFormula = BacktickExtractor.RewriteFormula(originalFormula, replacements);
         Debug.WriteLine($"Rewriting formula to: {newFormula}");
 
-        cell.Formula2 = newFormula;
-        ClearCellComment(cell);
+        WriteFormula(cell, newFormula);
+    }
+
+    private static void WriteFormula(dynamic cell, string formula)
+    {
+        try
+        {
+            cell.Formula2 = formula;
+            ClearCellComment(cell);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to write formula: {ex.Message}");
+            SetCellError(cell, $"Could not write formula: {ex.Message}");
+        }
     }
 
     private static void SetCellError(dynamic cell, string errorMessage)


### PR DESCRIPTION
Closes #110

## Changes

**LET variable column access validation** — When a backtick expression uses column access (`r[".."]`) on a LET variable (e.g. `sales` in `=LET(sales, tbl, ...)`), the pipeline appends `[#All]` to the variable name, producing invalid Excel syntax (`sales[#All]`). Now detected early with a clear error message instead of a cryptic COM exception.

**Broadened LET detection** — `ProcessCell` now routes to `ProcessLetFormula` when backticks appear in the result expression, not just in bindings.

**Formula write error handling** — Both `ProcessLetFormula` and `ProcessBacktickFormula` now use a `WriteFormula` helper that catches COM exceptions and surfaces "Could not write formula: ..." as a cell comment.

## Testing

- Added `LetFormula_ColumnAccessOnLetVariable_ShowsError` AddIn integration test
- All 356 unit tests pass
- 26/27 AddIn tests pass (1 pre-existing failure: #113)