### PR TITLE
Handle multiple backtick expressions in LET result (#113)

### DIFF
--- a/formula-boss.Tests/LetFormulaReconstructorTests.cs
+++ b/formula-boss.Tests/LetFormulaReconstructorTests.cs
@@ -252,6 +252,23 @@ public class LetFormulaReconstructorTests
         Assert.Contains("`filtered.max()`", editable);
     }
 
+    [Fact]
+    public void TryReconstruct_HandlesMultipleBacktickResultExpressions()
+    {
+        var processed = @"=LET(a, A1:A3, b, B1:B3,
+            _src__result_1, ""a.Sum()"",
+            _result_1, _RESULT_1(a),
+            _src__result_2, ""b.Sum()"",
+            _result_2, _RESULT_2(b),
+            _result_1 + _result_2)";
+
+        var result = LetFormulaReconstructor.TryReconstruct(processed, out var editable);
+
+        Assert.True(result);
+        Assert.NotNull(editable);
+        Assert.EndsWith("`a.Sum()` + `b.Sum()`)", editable);
+    }
+
     #endregion
 
     #region Header Binding Stripping

--- a/formula-boss.Tests/LetFormulaRewriterTests.cs
+++ b/formula-boss.Tests/LetFormulaRewriterTests.cs
@@ -87,14 +87,38 @@ public class LetFormulaRewriterTests
             ["filtered"] = new("filtered", "data.where(v => v > 0)", "FILTERED", new[] { "data" })
         };
 
-        var processedResult = new ProcessedBinding("_result", "filtered.max()", "_RESULT", new[] { "filtered" });
+        var processedResults = new[] { new ProcessedBinding("_result", "filtered.max()", "_RESULT", new[] { "filtered" }) };
 
-        var result = LetFormulaRewriter.Rewrite(structure!, processedBindings, processedResult);
+        var result = LetFormulaRewriter.Rewrite(structure!, processedBindings, processedResults);
 
         Assert.Contains("_src__result", result);
         Assert.Contains("\"filtered.max()\"", result);
         Assert.Contains("_result, _RESULT(filtered)", result);
         Assert.EndsWith("_result)", result.TrimEnd());
+    }
+
+    [Fact]
+    public void Rewrite_HandlesMultipleBacktickResultExpressions()
+    {
+        var formula = "=LET(a, A1:A3, b, B1:B3, `a.Sum()` + `b.Sum()`)";
+        LetFormulaParser.TryParse(formula, out var structure);
+
+        var processedResults = new[]
+        {
+            new ProcessedBinding("_result_1", "a.Sum()", "_RESULT_1", new[] { "a" }),
+            new ProcessedBinding("_result_2", "b.Sum()", "_RESULT_2", new[] { "b" })
+        };
+
+        var result = LetFormulaRewriter.Rewrite(structure!, new Dictionary<string, ProcessedBinding>(),
+            processedResults, "_result_1 + _result_2");
+
+        Assert.Contains("_src__result_1", result);
+        Assert.Contains("\"a.Sum()\"", result);
+        Assert.Contains("_result_1, _RESULT_1(a)", result);
+        Assert.Contains("_src__result_2", result);
+        Assert.Contains("\"b.Sum()\"", result);
+        Assert.Contains("_result_2, _RESULT_2(b)", result);
+        Assert.EndsWith("_result_1 + _result_2)", result.TrimEnd());
     }
 
     #endregion

--- a/formula-boss/Interception/FormulaInterceptor.cs
+++ b/formula-boss/Interception/FormulaInterceptor.cs
@@ -204,25 +204,29 @@ public class FormulaInterceptor : IDisposable
             }
         }
 
-        // Check if the result expression also contains a backtick
-        ProcessedBinding? processedResult = null;
+        // Check if the result expression also contains backtick(s)
+        var processedResults = new List<ProcessedBinding>();
+        string? rewrittenResultExpression = null;
         if (letStructure.ResultExpression.Contains('`'))
         {
-            var dslExpression = LetFormulaParser.ExtractBacktickExpression(letStructure.ResultExpression);
-            if (dslExpression != null)
+            var backtickExprs = BacktickExtractor.Extract(letStructure.ResultExpression);
+            for (var i = 0; i < backtickExprs.Count; i++)
             {
+                var dslExpression = backtickExprs[i].Expression;
+                var varName = backtickExprs.Count == 1 ? "_result" : $"_result_{i + 1}";
+
                 Debug.WriteLine($"Processing LET result expression: `{dslExpression}`");
 
-                var context = new ExpressionContext("_result");
+                var context = new ExpressionContext(varName);
                 var result = _pipeline.Process(dslExpression, context);
 
                 if (result.Success && result.UdfName != null)
                 {
-                    processedResult = new ProcessedBinding(
-                        "_result",
+                    processedResults.Add(new ProcessedBinding(
+                        varName,
                         dslExpression,
                         result.UdfName,
-                        result.Parameters ?? Array.Empty<string>());
+                        result.Parameters ?? Array.Empty<string>()));
 
                     Debug.WriteLine(
                         $"LET result UDF generated: {result.UdfName}({string.Join(", ", result.Parameters ?? Array.Empty<string>())})");
@@ -232,6 +236,19 @@ public class FormulaInterceptor : IDisposable
                     errors.Add($"Result expression: {result.ErrorMessage ?? "Unknown error"}");
                     Debug.WriteLine($"Pipeline error for result expression: {result.ErrorMessage}");
                 }
+            }
+
+            // Build the rewritten result expression by replacing backticks with variable names
+            if (processedResults.Count > 0 && processedResults.Count == backtickExprs.Count)
+            {
+                var replacements = new Dictionary<string, string>();
+                for (var i = 0; i < backtickExprs.Count; i++)
+                {
+                    replacements[backtickExprs[i].Expression] = processedResults[i].VariableName;
+                }
+
+                rewrittenResultExpression =
+                    BacktickExtractor.RewriteFormula(letStructure.ResultExpression, replacements);
             }
         }
 
@@ -261,7 +278,7 @@ public class FormulaInterceptor : IDisposable
             }
         }
 
-        if (processedResult != null)
+        foreach (var processedResult in processedResults)
         {
             foreach (var param in processedResult.Parameters)
             {
@@ -286,7 +303,8 @@ public class FormulaInterceptor : IDisposable
             return;
         }
 
-        var newFormula = LetFormulaRewriter.Rewrite(letStructure, processedBindings, processedResult);
+        var newFormula = LetFormulaRewriter.Rewrite(letStructure, processedBindings, processedResults,
+            rewrittenResultExpression);
         Debug.WriteLine($"Rewriting LET formula to: {newFormula}");
 
         WriteFormula(cell, newFormula);

--- a/formula-boss/Interception/LetFormulaReconstructor.cs
+++ b/formula-boss/Interception/LetFormulaReconstructor.cs
@@ -114,18 +114,31 @@ public static class LetFormulaReconstructor
         sb.Append(Indent);
         var resultExpr = structure.ResultExpression.Trim();
 
-        // Only replace result with backtick if it's the special _result variable
-        // (which means the original had a backtick expression in the result position)
-        // Don't replace if resultExpr is just a variable name like "maxYellow"
+        // Check for _result or _result_N variables and replace with backtick expressions
         if (resultExpr == "_result" && sourceExpressions.TryGetValue("_result", out var resultDsl))
         {
+            // Single backtick result
             sb.Append('`');
             sb.Append(resultDsl);
             sb.Append('`');
         }
         else
         {
-            sb.Append(resultExpr);
+            // Check for multiple _result_N references in the result expression
+            var reconstructed = resultExpr;
+            var hasResultVars = false;
+            foreach (var (varName, dsl) in sourceExpressions)
+            {
+                if (!varName.StartsWith("_result_", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                reconstructed = reconstructed.Replace(varName, $"`{dsl}`");
+                hasResultVars = true;
+            }
+
+            sb.Append(hasResultVars ? reconstructed : resultExpr);
         }
 
         sb.Append(')');

--- a/formula-boss/Interception/LetFormulaRewriter.cs
+++ b/formula-boss/Interception/LetFormulaRewriter.cs
@@ -32,7 +32,8 @@ public static class LetFormulaRewriter
     public static string Rewrite(
         LetStructure original,
         IReadOnlyDictionary<string, ProcessedBinding> processedBindings,
-        ProcessedBinding? processedResult = null)
+        IReadOnlyList<ProcessedBinding>? processedResults = null,
+        string? rewrittenResultExpression = null)
     {
         var sb = new StringBuilder();
         sb.Append("=LET(").Append(NewLine);
@@ -60,19 +61,22 @@ public static class LetFormulaRewriter
         }
 
         // Handle the result expression
-        if (processedResult != null)
+        if (processedResults is { Count: > 0 })
         {
-            // Result expression had a backtick - add _src_ doc and binding, then reference it
-            sb.Append(Indent).Append("_src_").Append(processedResult.VariableName).Append(", ");
-            sb.Append('"').Append(EscapeForExcelString(processedResult.OriginalExpression)).Append("\",")
-                .Append(NewLine);
+            // Result expression had backtick(s) - add _src_ doc and binding for each
+            foreach (var processedResult in processedResults)
+            {
+                sb.Append(Indent).Append("_src_").Append(processedResult.VariableName).Append(", ");
+                sb.Append('"').Append(EscapeForExcelString(processedResult.OriginalExpression)).Append("\",")
+                    .Append(NewLine);
 
-            sb.Append(Indent).Append(processedResult.VariableName).Append(", ");
-            AppendUdfCall(sb, processedResult);
-            sb.Append(',').Append(NewLine);
+                sb.Append(Indent).Append(processedResult.VariableName).Append(", ");
+                AppendUdfCall(sb, processedResult);
+                sb.Append(',').Append(NewLine);
+            }
 
-            // Final expression references the new binding
-            sb.Append(Indent).Append(processedResult.VariableName).Append(')');
+            // Final expression references the new bindings
+            sb.Append(Indent).Append(rewrittenResultExpression ?? processedResults[0].VariableName).Append(')');
         }
         else
         {


### PR DESCRIPTION
## Summary

- LET result expressions with multiple backtick expressions (e.g. `` `a.Sum()` + `b.Sum()` ``) now process all expressions, not just the first
- Each backtick in the result gets its own `_result_N` binding and UDF
- `LetFormulaReconstructor` can round-trip multi-backtick results back to editable form

Closes #113

## Test plan

- [x] Unit tests: new `Rewrite_HandlesMultipleBacktickResultExpressions` and `TryReconstruct_HandlesMultipleBacktickResultExpressions` pass
- [x] All existing tests pass (574 total: 357 unit + 161 runtime + 29 integration + 27 AddIn)
- [x] `LetFormula_TwoRange` AddIn test now passes (was the failing test from the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)