### PR TITLE
Fix LET variable intellisense outside backtick expressions

### DIFF
--- a/formula-boss.Tests/RoslynCompletionTests.cs
+++ b/formula-boss.Tests/RoslynCompletionTests.cs
@@ -131,4 +131,18 @@ public class RoslynCompletionTests : IDisposable
         Assert.DoesNotContain("GetHashCode", texts);
         Assert.DoesNotContain("GetType", texts);
     }
+
+    [Fact]
+    public async Task NonDslContext_ShowsLetVariables_WhenFormulaContainsBackticks()
+    {
+        var formula = "=LET(input, A1, myFormula, `Sales.Rows.Where(r => r.Amount > 100)`, )";
+        var textUp = "=LET(input, A1, myFormula, `Sales.Rows.Where(r => r.Amount > 100)`, ";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        var texts = items.Select(i => i.Text).ToList();
+        Assert.Contains("input", texts);
+        Assert.Contains("myFormula", texts);
+    }
 }

--- a/formula-boss/UI/Completion/RoslynCompletionProvider.cs
+++ b/formula-boss/UI/Completion/RoslynCompletionProvider.cs
@@ -1,6 +1,4 @@
-﻿using FormulaBoss.Interception;
-
-using Microsoft.CodeAnalysis.Completion;
+﻿using Microsoft.CodeAnalysis.Completion;
 
 namespace FormulaBoss.UI.Completion;
 
@@ -41,8 +39,9 @@ internal sealed class RoslynCompletionProvider
             return (items, false);
         }
 
-        // Outside DSL: use legacy top-level completions (table names, LET variables)
-        if (!ctx.InsideDsl && !BacktickExtractor.IsBacktickFormula(fullText))
+        // Outside DSL: use top-level completions (table names, LET variables).
+        // Check cursor context (InsideDsl), not whether formula contains backticks elsewhere.
+        if (!ctx.InsideDsl)
         {
             if (ctx.Type == DslType.TopLevel)
             {


### PR DESCRIPTION
Closes #115

## Summary
- Fixed condition in `RoslynCompletionProvider` that blocked LET variable completions when the cursor was outside backtick regions but the formula contained backtick expressions elsewhere
- The guard `!BacktickExtractor.IsBacktickFormula(fullText)` incorrectly checked the whole formula instead of cursor context (`ctx.InsideDsl`)
- Added test for the exact repro scenario

## Test plan
- [x] All 549 unit/integration tests pass
- [x] Manual test: open editor with `=LET(input, A1, myFormula, \`expr\`, |)` and verify intellisense shows `input` and `myFormula` at cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)