### PR TITLE
Update syntax highlighting and integrate Roslyn error diagnostics

### DIFF
--- a/formula-boss/UI/Completion/RoslynWorkspaceManager.cs
+++ b/formula-boss/UI/Completion/RoslynWorkspaceManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
 
 using FormulaBoss.Compilation;
 
@@ -43,20 +44,14 @@ internal sealed class RoslynWorkspaceManager : IDisposable
 
     public void Dispose() => _workspace.Dispose();
 
-    /// <summary>
-    ///     Updates the synthetic document and returns Roslyn completions at the given caret offset.
-    /// </summary>
-    public async Task<IReadOnlyList<CompletionItem>> GetCompletionsAsync(
-        string syntheticSource, int caretOffset, CancellationToken cancellationToken)
+    private void UpdateDocument(string syntheticSource)
     {
-        // Remove old document if present
         if (_documentId != null)
         {
             _workspace.TryApplyChanges(
                 _workspace.CurrentSolution.RemoveDocument(_documentId));
         }
 
-        // Add new document
         _documentId = DocumentId.CreateNewId(_projectId);
         var documentInfo = DocumentInfo.Create(
             _documentId,
@@ -67,6 +62,15 @@ internal sealed class RoslynWorkspaceManager : IDisposable
 
         _workspace.TryApplyChanges(
             _workspace.CurrentSolution.AddDocument(documentInfo));
+    }
+
+    /// <summary>
+    ///     Updates the synthetic document and returns Roslyn completions at the given caret offset.
+    /// </summary>
+    public async Task<IReadOnlyList<CompletionItem>> GetCompletionsAsync(
+        string syntheticSource, int caretOffset, CancellationToken cancellationToken)
+    {
+        UpdateDocument(syntheticSource);
 
         var document = _workspace.CurrentSolution.GetDocument(_documentId);
         if (document == null)
@@ -96,6 +100,43 @@ internal sealed class RoslynWorkspaceManager : IDisposable
         {
             Debug.WriteLine($"Roslyn completion error: {ex.Message}");
             return Array.Empty<CompletionItem>();
+        }
+    }
+
+    /// <summary>
+    ///     Updates the synthetic document and returns Roslyn semantic diagnostics.
+    /// </summary>
+    public async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
+        string syntheticSource, CancellationToken cancellationToken)
+    {
+        UpdateDocument(syntheticSource);
+
+        var document = _workspace.CurrentSolution.GetDocument(_documentId);
+        if (document == null)
+        {
+            return ImmutableArray<Diagnostic>.Empty;
+        }
+
+        try
+        {
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+            if (semanticModel == null)
+            {
+                return ImmutableArray<Diagnostic>.Empty;
+            }
+
+            return semanticModel.GetDiagnostics(cancellationToken: cancellationToken)
+                .Where(d => d.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning)
+                .ToImmutableArray();
+        }
+        catch (OperationCanceledException)
+        {
+            return ImmutableArray<Diagnostic>.Empty;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Roslyn diagnostics error: {ex.Message}");
+            return ImmutableArray<Diagnostic>.Empty;
         }
     }
 

--- a/formula-boss/UI/Completion/SyntheticDocumentBuilder.cs
+++ b/formula-boss/UI/Completion/SyntheticDocumentBuilder.cs
@@ -108,6 +108,108 @@ internal static class SyntheticDocumentBuilder
         return (sb.ToString(), caretOffset);
     }
 
+    /// <summary>
+    ///     Builds a synthetic C# document for Roslyn diagnostics and returns position mapping
+    ///     so diagnostic spans can be translated back to editor offsets.
+    /// </summary>
+    public static DiagnosticBuildResult? BuildForDiagnostics(string fullText, WorkbookMetadata? metadata)
+    {
+        // Find the last backtick expression
+        var expressions = BacktickExtractor.Extract(fullText);
+        if (expressions.Count == 0)
+        {
+            return null;
+        }
+
+        var lastExpr = expressions[^1];
+        var expressionText = lastExpr.Expression;
+        // +1 to skip the opening backtick character
+        var expressionStartInEditor = lastExpr.StartIndex + 1;
+
+        var sb = new StringBuilder(1024);
+
+        // Usings
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Collections;");
+        sb.AppendLine("using System.Collections.Generic;");
+        sb.AppendLine("using System.Linq;");
+        sb.AppendLine("using FormulaBoss.Runtime;");
+        sb.AppendLine();
+
+        // Generate typed row classes and typed table classes per table
+        var tableTypeNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (metadata != null)
+        {
+            foreach (var (tableName, columns) in metadata.TableColumns)
+            {
+                var safeTableName = SanitiseIdentifier(tableName);
+                if (string.IsNullOrEmpty(safeTableName))
+                {
+                    continue;
+                }
+
+                var rowTypeName = $"__{safeTableName}Row";
+                var rowCollTypeName = $"__{safeTableName}RowCollection";
+                var tableTypeName = $"__{safeTableName}Table";
+                tableTypeNames[tableName] = tableTypeName;
+
+                EmitTypedRow(sb, rowTypeName, columns);
+                EmitTypedRowCollection(sb, rowCollTypeName, rowTypeName);
+                EmitTypedTable(sb, tableTypeName, rowCollTypeName);
+            }
+        }
+
+        sb.AppendLine("class __Ctx {");
+        sb.AppendLine("void __M() {");
+
+        // Declare LET binding variables with appropriate types
+        var bindings = ExtractLetBindingsTyped(fullText, metadata, tableTypeNames);
+        var declaredNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (varName, typeName) in bindings)
+        {
+            sb.AppendLine($"{typeName} {varName} = default!;");
+            declaredNames.Add(varName);
+        }
+
+        // Declare table names and named ranges as variables
+        if (metadata != null)
+        {
+            foreach (var tableName in metadata.TableNames)
+            {
+                if (!declaredNames.Contains(tableName) && IsValidIdentifier(tableName) &&
+                    tableTypeNames.TryGetValue(tableName, out var tableTypeName))
+                {
+                    sb.AppendLine($"{tableTypeName} {tableName} = default!;");
+                    declaredNames.Add(tableName);
+                }
+            }
+
+            foreach (var name in metadata.NamedRanges)
+            {
+                if (!declaredNames.Contains(name) && IsValidIdentifier(name))
+                {
+                    sb.AppendLine($"ExcelArray {name} = default!;");
+                    declaredNames.Add(name);
+                }
+            }
+        }
+
+        // Embed the full expression and track its position
+        sb.Append("var __result = ");
+        var expressionStartInSynthetic = sb.Length;
+        sb.Append(expressionText);
+        sb.AppendLine(";");
+
+        sb.AppendLine("}");
+        sb.AppendLine("}");
+
+        return new DiagnosticBuildResult(
+            sb.ToString(),
+            expressionStartInSynthetic,
+            expressionStartInEditor,
+            expressionText.Length);
+    }
+
     private static void EmitTypedRow(StringBuilder sb, string rowTypeName, IReadOnlyList<string> columns)
     {
         sb.AppendLine($"class {rowTypeName} {{");
@@ -369,3 +471,9 @@ internal static class SyntheticDocumentBuilder
         name.Length > 0 && (char.IsLetter(name[0]) || name[0] == '_') &&
         name.All(c => char.IsLetterOrDigit(c) || c == '_');
 }
+
+internal sealed record DiagnosticBuildResult(
+    string Source,
+    int ExpressionStartInSynthetic,
+    int ExpressionStartInEditor,
+    int ExpressionLength);

--- a/formula-boss/UI/ErrorHighlighter.cs
+++ b/formula-boss/UI/ErrorHighlighter.cs
@@ -4,17 +4,16 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
 
+using FormulaBoss.UI.Completion;
+
 using ICSharpCode.AvalonEdit;
 using ICSharpCode.AvalonEdit.Document;
 using ICSharpCode.AvalonEdit.Rendering;
 
-using FormulaBoss.Interception;
-using FormulaBoss.Parsing;
-
 namespace FormulaBoss.UI;
 
 /// <summary>
-///     Highlights parse errors in backtick expressions with red squiggly underlines.
+///     Highlights Roslyn compile errors in backtick expressions with red squiggly underlines.
 ///     Shows tooltip messages on mouse hover over error regions.
 /// </summary>
 internal sealed class ErrorHighlighter : IBackgroundRenderer
@@ -23,12 +22,20 @@ internal sealed class ErrorHighlighter : IBackgroundRenderer
     private readonly DispatcherTimer _debounceTimer;
     private readonly Pen _squigglePen;
     private readonly ToolTip _tooltip;
+    private readonly Func<RoslynWorkspaceManager?> _getWorkspace;
+    private readonly Func<WorkbookMetadata?> _getMetadata;
 
+    private CancellationTokenSource? _diagnosticCts;
     private List<ErrorMarker> _markers = [];
 
-    public ErrorHighlighter(TextEditor editor)
+    public ErrorHighlighter(
+        TextEditor editor,
+        Func<RoslynWorkspaceManager?> getWorkspace,
+        Func<WorkbookMetadata?> getMetadata)
     {
         _editor = editor;
+        _getWorkspace = getWorkspace;
+        _getMetadata = getMetadata;
 
         var red = Color.FromRgb(0xFF, 0x30, 0x30);
         _squigglePen = new Pen(new SolidColorBrush(red), 1.2) { DashStyle = DashStyles.Dot };
@@ -36,12 +43,8 @@ internal sealed class ErrorHighlighter : IBackgroundRenderer
 
         _tooltip = new ToolTip { Placement = System.Windows.Controls.Primitives.PlacementMode.Mouse };
 
-        _debounceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(300) };
-        _debounceTimer.Tick += (_, _) =>
-        {
-            _debounceTimer.Stop();
-            UpdateErrors();
-        };
+        _debounceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
+        _debounceTimer.Tick += OnDebounceTimerTick;
 
         editor.TextArea.TextView.BackgroundRenderers.Add(this);
         editor.TextChanged += (_, _) =>
@@ -109,37 +112,76 @@ internal sealed class ErrorHighlighter : IBackgroundRenderer
         dc.DrawGeometry(null, _squigglePen, geometry);
     }
 
-    private void UpdateErrors()
+    private async void OnDebounceTimerTick(object? sender, EventArgs e)
     {
-        var text = _editor.Text;
-        var newMarkers = new List<ErrorMarker>();
+        _debounceTimer.Stop();
+        _diagnosticCts?.Cancel();
+        _diagnosticCts = new CancellationTokenSource();
+        var ct = _diagnosticCts.Token;
 
-        var expressions = BacktickExtractor.Extract(text);
-        foreach (var expr in expressions)
+        try
         {
-            // Lex and parse the backtick expression
-            var lexer = new Lexer(expr.Expression);
-            var tokens = lexer.ScanTokens();
+            await UpdateErrorsAsync(ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when user types quickly
+        }
+    }
 
-            // Collect lexer errors (tokens with TokenType.Error)
-            foreach (var token in tokens)
+    private async Task UpdateErrorsAsync(CancellationToken ct)
+    {
+        var workspace = _getWorkspace();
+        if (workspace == null)
+        {
+            return;
+        }
+
+        var text = _editor.Text;
+        var metadata = _getMetadata();
+
+        var buildResult = SyntheticDocumentBuilder.BuildForDiagnostics(text, metadata);
+        if (buildResult == null)
+        {
+            _markers = [];
+            _editor.TextArea.TextView.InvalidateLayer(Layer);
+            return;
+        }
+
+        ct.ThrowIfCancellationRequested();
+
+        var diagnostics = await workspace.GetDiagnosticsAsync(buildResult.Source, ct);
+
+        ct.ThrowIfCancellationRequested();
+
+        var newMarkers = new List<ErrorMarker>();
+        var exprStart = buildResult.ExpressionStartInSynthetic;
+        var exprEnd = exprStart + buildResult.ExpressionLength;
+
+        foreach (var diagnostic in diagnostics)
+        {
+            var span = diagnostic.Location.SourceSpan;
+
+            // Only show diagnostics within the expression region
+            if (span.Start < exprStart || span.Start >= exprEnd)
             {
-                if (token.Type == TokenType.Error)
-                {
-                    // +1 skips the opening backtick
-                    var offset = expr.StartIndex + 1 + token.Position;
-                    newMarkers.Add(new ErrorMarker(offset, Math.Max(1, token.Lexeme.Length), token.Lexeme));
-                }
+                continue;
             }
 
-            // Collect parser errors
-            var parser = new Parser(tokens, expr.Expression);
-            parser.Parse();
-            foreach (var (position, length, message) in parser.StructuredErrors)
+            // Filter trailing diagnostics to reduce noise while typing
+            if (span.Start >= exprEnd - 2)
             {
-                var offset = expr.StartIndex + 1 + position;
-                newMarkers.Add(new ErrorMarker(offset, length, message));
+                continue;
             }
+
+            var editorOffset = (span.Start - exprStart) + buildResult.ExpressionStartInEditor;
+            var length = Math.Min(span.Length, buildResult.ExpressionLength - (span.Start - exprStart));
+            if (length <= 0)
+            {
+                length = 1;
+            }
+
+            newMarkers.Add(new ErrorMarker(editorOffset, length, diagnostic.GetMessage()));
         }
 
         _markers = newMarkers;

--- a/formula-boss/UI/FloatingEditorWindow.xaml.cs
+++ b/formula-boss/UI/FloatingEditorWindow.xaml.cs
@@ -44,8 +44,11 @@ public partial class FloatingEditorWindow
         // Bracket matching highlight
         _ = new BracketHighlighter(FormulaEditor);
 
-        // Real-time parse error squiggles
-        _ = new ErrorHighlighter(FormulaEditor);
+        // Real-time Roslyn error squiggles
+        _ = new ErrorHighlighter(
+            FormulaEditor,
+            () => { EnsureWorkspace(); return _workspaceManager; },
+            () => Metadata);
 
         // Editor behaviors (subscribes to TextEntering/TextEntered/PreviewKeyDown internally)
         _behaviorHandler = new EditorBehaviorHandler(FormulaEditor)

--- a/formula-boss/UI/FormulaBossSyntax.xshd
+++ b/formula-boss/UI/FormulaBossSyntax.xshd
@@ -41,7 +41,7 @@
     <!-- Comparison operators -->
     <Rule color="Operator">==|!=|&gt;=|&lt;=|&gt;|&lt;</Rule>
 
-    <!-- C# keywords used in statement lambdas -->
+    <!-- C# keywords -->
     <Keywords color="Keyword">
       <Word>var</Word>
       <Word>return</Word>
@@ -51,60 +51,68 @@
       <Word>true</Word>
       <Word>false</Word>
       <Word>null</Word>
+      <Word>for</Word>
+      <Word>foreach</Word>
+      <Word>while</Word>
+      <Word>break</Word>
+      <Word>continue</Word>
+      <Word>switch</Word>
+      <Word>case</Word>
+      <Word>in</Word>
     </Keywords>
 
-    <!-- Data accessor methods -->
+    <!-- Data accessor properties -->
     <Keywords color="Accessor">
-      <Word>cells</Word>
-      <Word>values</Word>
-      <Word>rows</Word>
-      <Word>cols</Word>
-      <Word>withHeaders</Word>
+      <Word>Rows</Word>
+      <Word>Cells</Word>
+      <Word>Cell</Word>
+      <Word>RawValue</Word>
+      <Word>RowCount</Word>
+      <Word>ColCount</Word>
+      <Word>Headers</Word>
+      <Word>ColumnCount</Word>
     </Keywords>
 
-    <!-- LINQ-style methods -->
+    <!-- LINQ-style and collection methods -->
     <Keywords color="Method">
-      <Word>where</Word>
-      <Word>select</Word>
-      <Word>find</Word>
-      <Word>some</Word>
-      <Word>every</Word>
-      <Word>map</Word>
-      <Word>orderBy</Word>
-      <Word>orderByDesc</Word>
-      <Word>take</Word>
-      <Word>skip</Word>
-      <Word>distinct</Word>
-      <Word>groupBy</Word>
-      <Word>reduce</Word>
-      <Word>aggregate</Word>
-      <Word>scan</Word>
-      <Word>sum</Word>
-      <Word>avg</Word>
-      <Word>average</Word>
-      <Word>min</Word>
-      <Word>max</Word>
-      <Word>count</Word>
-      <Word>first</Word>
-      <Word>firstOrDefault</Word>
-      <Word>last</Word>
-      <Word>lastOrDefault</Word>
-      <Word>toArray</Word>
+      <Word>Where</Word>
+      <Word>Select</Word>
+      <Word>SelectMany</Word>
+      <Word>Map</Word>
+      <Word>Any</Word>
+      <Word>All</Word>
+      <Word>First</Word>
+      <Word>FirstOrDefault</Word>
+      <Word>OrderBy</Word>
+      <Word>OrderByDescending</Word>
+      <Word>Take</Word>
+      <Word>Skip</Word>
+      <Word>Distinct</Word>
+      <Word>Count</Word>
+      <Word>Sum</Word>
+      <Word>Min</Word>
+      <Word>Max</Word>
+      <Word>Average</Word>
+      <Word>Aggregate</Word>
+      <Word>Scan</Word>
+      <Word>ToRange</Word>
     </Keywords>
 
     <!-- Cell properties -->
     <Keywords color="CellProperty">
-      <Word>value</Word>
-      <Word>color</Word>
-      <Word>rgb</Word>
-      <Word>bold</Word>
-      <Word>italic</Word>
-      <Word>fontSize</Word>
-      <Word>format</Word>
-      <Word>formula</Word>
-      <Word>row</Word>
-      <Word>col</Word>
-      <Word>address</Word>
+      <Word>Value</Word>
+      <Word>Color</Word>
+      <Word>Rgb</Word>
+      <Word>Bold</Word>
+      <Word>Italic</Word>
+      <Word>FontSize</Word>
+      <Word>Format</Word>
+      <Word>Formula</Word>
+      <Word>Row</Word>
+      <Word>Col</Word>
+      <Word>Address</Word>
+      <Word>Interior</Word>
+      <Word>Font</Word>
     </Keywords>
 
     <!-- Numbers -->


### PR DESCRIPTION
## Summary

Closes #65

- **Syntax highlighting (.xshd):** Updated from camelCase DSL methods (`where`, `select`, `orderBy`) to PascalCase C# API names (`Where`, `Select`, `OrderBy`). Added statement keywords (`for`, `foreach`, `while`, `switch`, `case`, `in`).
- **Error diagnostics:** Replaced custom Lexer/Parser error detection with Roslyn semantic diagnostics. `ErrorHighlighter` now builds a synthetic C# document via `SyntheticDocumentBuilder.BuildForDiagnostics()`, gets diagnostics from `RoslynWorkspaceManager.GetDiagnosticsAsync()`, and maps positions back to editor offsets.
- **Shared workspace:** Diagnostics reuse the existing Roslyn workspace (no contention — both run on WPF dispatcher thread). Document update logic extracted to shared `UpdateDocument()` method.
- **Debouncing:** 500ms debounce with `CancellationTokenSource` to discard stale results during rapid typing. Trailing diagnostics (last 2 chars) filtered to reduce noise.

## Test plan

- [x] `dotnet build` — clean build
- [x] `dotnet test` — all 549 tests pass
- [x] Manual: open editor, verify PascalCase methods are syntax-highlighted
- [x] Manual: type expression with error (e.g., undefined column) — verify red squiggle
- [x] Manual: type valid expression — verify no squiggles
- [x] Manual: verify intellisense completions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)