### PR TITLE
Remember floating editor position within session

### DIFF
--- a/formula-boss/Commands/ShowFloatingEditorCommand.cs
+++ b/formula-boss/Commands/ShowFloatingEditorCommand.cs
@@ -32,6 +32,10 @@ public static class ShowFloatingEditorCommand
     private static int _targetCellScreenTop;
     private static double _targetMonitorScale = 1.0;
 
+    // True after the editor has been positioned at least once — subsequent opens
+    // reuse whatever position the user left the window in (session-only memory).
+    private static bool _hasBeenPositioned;
+
     /// <summary>
     ///     Initializes the command with the Excel application reference.
     ///     Must be called during add-in initialization.
@@ -62,6 +66,7 @@ public static class ShowFloatingEditorCommand
         _window = null;
         _app = null;
         _targetAddress = null;
+        _hasBeenPositioned = false;
     }
 
     /// <summary>
@@ -116,9 +121,6 @@ public static class ShowFloatingEditorCommand
                         _targetAddress = currentAddress;
                         _window.Metadata = metadata;
                         _window.FormulaText = editorContent;
-
-                        var wpfHwnd = new WindowInteropHelper(_window).EnsureHandle();
-                        WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
                     }
                 }
                 else
@@ -131,8 +133,12 @@ public static class ShowFloatingEditorCommand
                     _window.Metadata = metadata;
                     _window.FormulaText = editorContent;
 
-                    var wpfHwnd = new WindowInteropHelper(_window).EnsureHandle();
-                    WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
+                    if (!_hasBeenPositioned)
+                    {
+                        var wpfHwnd = new WindowInteropHelper(_window).EnsureHandle();
+                        WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
+                        _hasBeenPositioned = true;
+                    }
 
                     _window.Show();
                     _window.Activate();


### PR DESCRIPTION
## Summary
- Only center the editor on Excel the first time it opens per session
- Subsequent opens reuse wherever the user last positioned the window
- Reset flag on cleanup so a fresh add-in load starts centered again

Closes #52

## Test plan
- [x] All 581 existing tests pass (unit, integration, addin)
- [x] Manual: open editor → drag to corner → close → reopen → verify it appears in the same spot
- [x] Manual: close Excel → reopen → verify editor starts centered (not persisted across sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)