### PR TITLE
Swap Enter and Ctrl+Enter in floating editor

### DIFF
--- a/formula-boss/UI/EditorBehaviorHandler.cs
+++ b/formula-boss/UI/EditorBehaviorHandler.cs
@@ -56,7 +56,7 @@ internal class EditorBehaviorHandler
     public Action? ForceCompletionRequested { get; set; }
 
     /// <summary>
-    ///     Invoked when Ctrl+Enter is pressed to apply the formula.
+    ///     Invoked when Enter is pressed to apply the formula.
     /// </summary>
     public Action<string>? FormulaApplyRequested { get; set; }
 
@@ -160,15 +160,15 @@ internal class EditorBehaviorHandler
 
             if (e.Key == Key.Enter && e.KeyboardDevice.Modifiers == ModifierKeys.None)
             {
-                HandleEnter();
                 e.Handled = true;
+                FormulaApplyRequested?.Invoke(_editor.Text);
                 return;
             }
 
             if (e is { Key: Key.Enter, KeyboardDevice.Modifiers: ModifierKeys.Control })
             {
+                HandleEnter();
                 e.Handled = true;
-                FormulaApplyRequested?.Invoke(_editor.Text);
                 return;
             }
 


### PR DESCRIPTION
## Summary

- **Enter** now applies the formula to the cell (previously Ctrl+Enter)
- **Ctrl+Enter** now inserts newlines with code formatting (previously Enter)

This matches Excel convention where Enter confirms cell input. Users reopening the editor on an existing UDF can now press Enter to rewrite the formula, matching the behavior of creating a new UDF via direct cell entry.

Closes #139

## Test plan

- [ ] Open editor on empty cell, type a backtick formula, press Enter → formula is applied
- [ ] Open editor on cell with existing LET UDF, edit the expression, press Enter → UDF is rewritten
- [ ] In the editor, press Ctrl+Enter → newline is inserted with proper indentation
- [ ] Ctrl+Enter between `{}` → brace block expands correctly
- [ ] All 364 unit tests pass ✅
- [ ] All 31 AddIn tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)