### PR TITLE
Add signature help popup UI and editor wiring

### DIFF
--- a/formula-boss/UI/EditorBehaviorHandler.cs
+++ b/formula-boss/UI/EditorBehaviorHandler.cs
@@ -83,6 +83,34 @@ internal class EditorBehaviorHandler
     /// </summary>
     public Func<bool>? IsCompletionWindowOpen { get; set; }
 
+    /// <summary>
+    ///     Invoked when signature help should be shown or updated (on '(' or ',').
+    /// </summary>
+    public Action? SignatureHelpRequested { get; set; }
+
+    /// <summary>
+    ///     Invoked when signature help should be dismissed (on ')' or Escape).
+    /// </summary>
+    public Action? SignatureHelpDismissRequested { get; set; }
+
+    /// <summary>
+    ///     Returns true when the signature help popup is visible, so Up/Down
+    ///     can cycle overloads instead of moving the caret.
+    /// </summary>
+    public Func<bool>? IsSignatureHelpVisible { get; set; }
+
+    /// <summary>
+    ///     Invoked when the user presses Down to cycle to the next overload.
+    ///     Returns true if consumed.
+    /// </summary>
+    public Func<bool>? NextOverload { get; set; }
+
+    /// <summary>
+    ///     Invoked when the user presses Up to cycle to the previous overload.
+    ///     Returns true if consumed.
+    /// </summary>
+    public Func<bool>? PreviousOverload { get; set; }
+
     private void OnTextEntering(object sender, TextCompositionEventArgs e)
     {
         try
@@ -136,6 +164,15 @@ internal class EditorBehaviorHandler
                 CompletionRequested?.Invoke(ch);
             }
 
+            if (ch is '(' or ',')
+            {
+                SignatureHelpRequested?.Invoke();
+            }
+            else if (ch == ')')
+            {
+                SignatureHelpDismissRequested?.Invoke();
+            }
+
             if (IsCompletionListEmpty?.Invoke() == true)
             {
                 CompletionCloseRequested?.Invoke(ch);
@@ -151,6 +188,44 @@ internal class EditorBehaviorHandler
     {
         try
         {
+            // Up/Down cycle overloads when signature help is visible and completion is not
+            if (e.Key == Key.Down && e.KeyboardDevice.Modifiers == ModifierKeys.None
+                && IsCompletionWindowOpen?.Invoke() != true
+                && IsSignatureHelpVisible?.Invoke() == true)
+            {
+                if (NextOverload?.Invoke() == true)
+                {
+                    e.Handled = true;
+                    return;
+                }
+            }
+
+            if (e.Key == Key.Up && e.KeyboardDevice.Modifiers == ModifierKeys.None
+                && IsCompletionWindowOpen?.Invoke() != true
+                && IsSignatureHelpVisible?.Invoke() == true)
+            {
+                if (PreviousOverload?.Invoke() == true)
+                {
+                    e.Handled = true;
+                    return;
+                }
+            }
+
+            // Escape: close completion first, then signature help
+            if (e.Key == Key.Escape && e.KeyboardDevice.Modifiers == ModifierKeys.None)
+            {
+                if (IsCompletionWindowOpen?.Invoke() == true)
+                {
+                    // Let AvalonEdit's CompletionWindow handle the Escape
+                }
+                else if (IsSignatureHelpVisible?.Invoke() == true)
+                {
+                    SignatureHelpDismissRequested?.Invoke();
+                    e.Handled = true;
+                    return;
+                }
+            }
+
             if (e is { Key: Key.Space, KeyboardDevice.Modifiers: ModifierKeys.Control })
             {
                 e.Handled = true;
@@ -797,6 +872,14 @@ internal class EditorBehaviorHandler
         try
         {
             var currentLine = _editor.TextArea.Caret.Line;
+
+            // Re-trigger signature help when the popup is already visible
+            // to update active parameter as the caret moves between arguments
+            if (IsSignatureHelpVisible?.Invoke() == true)
+            {
+                SignatureHelpRequested?.Invoke();
+            }
+
             if (currentLine == _lastCaretLine)
             {
                 return;

--- a/formula-boss/UI/FloatingEditorWindow.xaml.cs
+++ b/formula-boss/UI/FloatingEditorWindow.xaml.cs
@@ -23,7 +23,10 @@ public partial class FloatingEditorWindow
     private bool _sizeChanged;
     private RoslynWorkspaceManager? _workspaceManager;
     private RoslynCompletionProvider? _completionProvider;
+    private SignatureHelpProvider? _signatureHelpProvider;
+    private SignatureHelpPopup? _signatureHelpPopup;
     private CancellationTokenSource? _completionCts;
+    private CancellationTokenSource? _signatureHelpCts;
 
     public FloatingEditorWindow()
     {
@@ -63,12 +66,18 @@ public partial class FloatingEditorWindow
             },
             FormulaApplyRequested = text =>
             {
+                DismissSignatureHelp();
                 FormulaApplied?.Invoke(this, text);
                 Hide();
             },
             IsCompletionListEmpty = () =>
                 _completionWindow != null && _completionWindow.CompletionList.ListBox.Items.Count == 0,
-            IsCompletionWindowOpen = () => _completionWindow != null
+            IsCompletionWindowOpen = () => _completionWindow != null,
+            SignatureHelpRequested = () => ShowSignatureHelp(),
+            SignatureHelpDismissRequested = DismissSignatureHelp,
+            IsSignatureHelpVisible = () => _signatureHelpPopup?.IsVisible == true,
+            NextOverload = () => _signatureHelpPopup?.NextOverload() == true,
+            PreviousOverload = () => _signatureHelpPopup?.PreviousOverload() == true
         };
 
         // Track size changes with debounced save
@@ -90,6 +99,9 @@ public partial class FloatingEditorWindow
                 FormulaEditor.SelectAll();
             }
         };
+
+        // Dismiss signature help when editor loses focus
+        Deactivated += (_, _) => DismissSignatureHelp();
     }
 
     /// <summary>
@@ -128,6 +140,7 @@ public partial class FloatingEditorWindow
 
         _workspaceManager = new RoslynWorkspaceManager();
         _completionProvider = new RoslynCompletionProvider(_workspaceManager);
+        _signatureHelpProvider = new SignatureHelpProvider(_workspaceManager);
 
         // Fire-and-forget warm-up
         _ = _workspaceManager.WarmUpAsync();
@@ -230,6 +243,50 @@ public partial class FloatingEditorWindow
         };
     }
 
+    private async void ShowSignatureHelp()
+    {
+        EnsureWorkspace();
+
+        _signatureHelpCts?.Cancel();
+        _signatureHelpCts = new CancellationTokenSource();
+        var ct = _signatureHelpCts.Token;
+
+        var textUpToCaret = FormulaEditor.Document.GetText(0, FormulaEditor.CaretOffset);
+        var fullText = FormulaEditor.Text;
+
+        SignatureHelpModel? model;
+
+        try
+        {
+            model = await _signatureHelpProvider!.GetSignatureHelpAsync(
+                textUpToCaret, fullText, Metadata, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        if (ct.IsCancellationRequested)
+        {
+            return;
+        }
+
+        if (model == null)
+        {
+            DismissSignatureHelp();
+            return;
+        }
+
+        _signatureHelpPopup ??= new SignatureHelpPopup(FormulaEditor);
+        _signatureHelpPopup.Update(model);
+    }
+
+    private void DismissSignatureHelp()
+    {
+        _signatureHelpCts?.Cancel();
+        _signatureHelpPopup?.Hide();
+    }
+
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
     {
         _sizeChanged = true;
@@ -261,6 +318,7 @@ public partial class FloatingEditorWindow
     {
         // Don't actually close, just hide - we reuse the window
         e.Cancel = true;
+        DismissSignatureHelp();
         Hide();
     }
 
@@ -269,8 +327,13 @@ public partial class FloatingEditorWindow
         _completionCts?.Cancel();
         _completionCts?.Dispose();
         _completionCts = null;
+        _signatureHelpCts?.Cancel();
+        _signatureHelpCts?.Dispose();
+        _signatureHelpCts = null;
+        DismissSignatureHelp();
         _workspaceManager?.Dispose();
         _workspaceManager = null;
         _completionProvider = null;
+        _signatureHelpProvider = null;
     }
 }

--- a/formula-boss/UI/SignatureHelpPopup.cs
+++ b/formula-boss/UI/SignatureHelpPopup.cs
@@ -1,0 +1,260 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+using FormulaBoss.UI.Completion;
+
+using ICSharpCode.AvalonEdit;
+
+namespace FormulaBoss.UI;
+
+/// <summary>
+///     Displays VS-style signature help (parameter info) near the caret.
+///     Shows method signature with active parameter bold, overload counter,
+///     method summary, and active parameter description.
+/// </summary>
+internal sealed class SignatureHelpPopup
+{
+    private static readonly Brush BackgroundBrush = new SolidColorBrush(Color.FromRgb(0xF6, 0xF6, 0xF6));
+    private static readonly Brush BorderBrush = new SolidColorBrush(Color.FromRgb(0xCC, 0xCE, 0xDB));
+
+    private readonly TextEditor _editor;
+    private readonly Popup _popup;
+    private readonly TextBlock _overloadCounter;
+    private readonly TextBlock _signatureLine;
+    private readonly TextBlock _summaryText;
+    private readonly TextBlock _parameterText;
+
+    private SignatureHelpModel? _model;
+    private int _selectedOverloadIndex;
+
+    public SignatureHelpPopup(TextEditor editor)
+    {
+        _editor = editor;
+
+        _overloadCounter = new TextBlock
+        {
+            FontFamily = new FontFamily("Segoe UI"),
+            FontSize = 12,
+            Foreground = Brushes.Gray,
+            Margin = new Thickness(0, 0, 6, 0),
+            VerticalAlignment = VerticalAlignment.Center
+        };
+
+        _signatureLine = new TextBlock
+        {
+            FontFamily = new FontFamily("Consolas"),
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+
+        var headerPanel = new DockPanel { Margin = new Thickness(0, 0, 0, 2) };
+        DockPanel.SetDock(_overloadCounter, Dock.Left);
+        headerPanel.Children.Add(_overloadCounter);
+        headerPanel.Children.Add(_signatureLine);
+
+        _summaryText = new TextBlock
+        {
+            FontFamily = new FontFamily("Segoe UI"),
+            FontSize = 12,
+            Foreground = Brushes.DimGray,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 2, 0, 0)
+        };
+
+        _parameterText = new TextBlock
+        {
+            FontFamily = new FontFamily("Segoe UI"),
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 2, 0, 0)
+        };
+
+        var panel = new StackPanel { Margin = new Thickness(6, 4, 6, 4) };
+        panel.Children.Add(headerPanel);
+        panel.Children.Add(_summaryText);
+        panel.Children.Add(_parameterText);
+
+        var border = new Border
+        {
+            Background = BackgroundBrush,
+            BorderBrush = BorderBrush,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(2),
+            MaxWidth = 500,
+            Child = panel
+        };
+
+        _popup = new Popup
+        {
+            Child = border,
+            Placement = PlacementMode.Custom,
+            CustomPopupPlacementCallback = PlacePopup,
+            PlacementTarget = editor.TextArea.TextView,
+            StaysOpen = true,
+            AllowsTransparency = true
+        };
+    }
+
+    public bool IsVisible => _popup.IsOpen;
+
+    public void Update(SignatureHelpModel model)
+    {
+        _model = model;
+
+        // Preserve user's overload selection if still valid, otherwise use Roslyn's suggestion
+        if (_selectedOverloadIndex >= model.Overloads.Count)
+        {
+            _selectedOverloadIndex = model.ActiveOverloadIndex;
+        }
+
+        Render();
+        _popup.IsOpen = true;
+    }
+
+    public void Hide()
+    {
+        _popup.IsOpen = false;
+        _model = null;
+        _selectedOverloadIndex = 0;
+    }
+
+    /// <summary>
+    ///     Cycles to the next overload. Returns true if consumed (multiple overloads exist).
+    /// </summary>
+    public bool NextOverload()
+    {
+        if (_model == null || _model.Overloads.Count <= 1)
+        {
+            return false;
+        }
+
+        _selectedOverloadIndex = (_selectedOverloadIndex + 1) % _model.Overloads.Count;
+        Render();
+        return true;
+    }
+
+    /// <summary>
+    ///     Cycles to the previous overload. Returns true if consumed (multiple overloads exist).
+    /// </summary>
+    public bool PreviousOverload()
+    {
+        if (_model == null || _model.Overloads.Count <= 1)
+        {
+            return false;
+        }
+
+        _selectedOverloadIndex = (_selectedOverloadIndex - 1 + _model.Overloads.Count) % _model.Overloads.Count;
+        Render();
+        return true;
+    }
+
+    private void Render()
+    {
+        if (_model == null)
+        {
+            return;
+        }
+
+        var overload = _model.Overloads[_selectedOverloadIndex];
+        var activeParam = _model.ActiveParameterIndex;
+
+        // Overload counter
+        if (_model.Overloads.Count > 1)
+        {
+            _overloadCounter.Text = $"\u25B2 {_selectedOverloadIndex + 1} of {_model.Overloads.Count} \u25BC";
+            _overloadCounter.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            _overloadCounter.Visibility = Visibility.Collapsed;
+        }
+
+        // Signature line with active parameter bold
+        _signatureLine.Inlines.Clear();
+        _signatureLine.Inlines.Add(new Run(overload.MethodName + "("));
+
+        for (var i = 0; i < overload.Parameters.Count; i++)
+        {
+            if (i > 0)
+            {
+                _signatureLine.Inlines.Add(new Run(", "));
+            }
+
+            var param = overload.Parameters[i];
+            var paramText = $"{param.Type} {param.Name}";
+            var run = new Run(paramText);
+
+            if (i == activeParam)
+            {
+                run.FontWeight = FontWeights.Bold;
+            }
+
+            _signatureLine.Inlines.Add(run);
+        }
+
+        _signatureLine.Inlines.Add(new Run("): " + overload.ReturnType));
+
+        // Summary
+        if (!string.IsNullOrEmpty(overload.Summary))
+        {
+            _summaryText.Text = overload.Summary;
+            _summaryText.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            _summaryText.Visibility = Visibility.Collapsed;
+        }
+
+        // Active parameter description
+        if (activeParam >= 0 && activeParam < overload.Parameters.Count)
+        {
+            var param = overload.Parameters[activeParam];
+            if (!string.IsNullOrEmpty(param.Description))
+            {
+                _parameterText.Inlines.Clear();
+                _parameterText.Inlines.Add(new Run(param.Name + ": ") { FontWeight = FontWeights.SemiBold });
+                _parameterText.Inlines.Add(new Run(param.Description));
+                _parameterText.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                _parameterText.Visibility = Visibility.Collapsed;
+            }
+        }
+        else
+        {
+            _parameterText.Visibility = Visibility.Collapsed;
+        }
+
+        // Reposition to current caret
+        _popup.HorizontalOffset = 0; // Force WPF to recalculate placement
+    }
+
+    private CustomPopupPlacement[] PlacePopup(Size popupSize, Size targetSize, Point offset)
+    {
+        var textView = _editor.TextArea.TextView;
+        var caretPos = textView.GetVisualPosition(
+            _editor.TextArea.Caret.Position,
+            ICSharpCode.AvalonEdit.Rendering.VisualYPosition.LineTop);
+        var caretScreen = textView.PointToScreen(caretPos);
+        var targetScreen = textView.PointToScreen(new Point(0, 0));
+
+        var x = caretScreen.X - targetScreen.X;
+        var y = caretScreen.Y - targetScreen.Y - popupSize.Height - 2;
+
+        // If not enough room above, place below the line
+        if (y < 0)
+        {
+            var lineBottom = textView.GetVisualPosition(
+                _editor.TextArea.Caret.Position,
+                ICSharpCode.AvalonEdit.Rendering.VisualYPosition.LineBottom);
+            y = textView.PointToScreen(lineBottom).Y - targetScreen.Y + 2;
+        }
+
+        return [new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.Horizontal)];
+    }
+}


### PR DESCRIPTION
## Summary

- **New `SignatureHelpPopup`** — WPF `Popup` showing method signature with active parameter bold, overload counter ("1 of 3"), method summary, and parameter description
- **`EditorBehaviorHandler`** — trigger on `(` and `,`, dismiss on `)` and Escape, Up/Down overload cycling when completion window is not open
- **`FloatingEditorWindow`** — `ShowSignatureHelp()` async method, `_signatureHelpPopup` field, lifecycle management (dismiss on apply, close, focus loss)

## Test plan

- [x] Type `table.Rows().Where(` → verify popup appears with signature
- [x] Type `,` → verify active parameter updates
- [x] Press Up/Down → verify overload cycles
- [x] Press `)` → verify popup dismisses
- [x] Press Escape with completion open → closes completion; press Escape again → closes signature help
- [x] Verify coexistence: completion below caret, signature help above
- [x] Verify popup dismisses on editor losing focus

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)