### PR TITLE
Harmonize runtime using directives with intellisense

### DIFF
--- a/formula-boss/Transpilation/CodeEmitter.cs
+++ b/formula-boss/Transpilation/CodeEmitter.cs
@@ -208,7 +208,11 @@ public class CodeEmitter
 
         // Using directives
         sb.AppendLine("using System;");
+        sb.AppendLine("using System.Collections;");
+        sb.AppendLine("using System.Collections.Generic;");
         sb.AppendLine("using System.Linq;");
+        sb.AppendLine("using System.Text;");
+        sb.AppendLine("using System.Text.RegularExpressions;");
         sb.AppendLine("using FormulaBoss.Runtime;");
         sb.AppendLine();
 


### PR DESCRIPTION
## Summary
- CodeEmitter only injected `System`, `System.Linq`, and `FormulaBoss.Runtime` into generated code, while SyntheticDocumentBuilder (intellisense) also included `System.Collections`, `System.Collections.Generic`, `System.Text`, and `System.Text.RegularExpressions`
- This meant autocomplete would suggest types like `List<T>`, `Dictionary<K,V>`, `StringBuilder`, and `Regex`, but they'd fail at compile time
- Added the 4 missing `using` directives to CodeEmitter so runtime matches intellisense

## Test plan
- [x] All 628 tests pass (182 Runtime, 378 unit, 34 integration, 34 AddIn)
- [x] Manual: write an expression using `new List<int> { 1, 2, 3 }` and verify it compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)