### PR TITLE
Implement IEnumerable on ExcelValue and Row, add ForEach

### DIFF
--- a/formula-boss.Runtime.Tests/ExcelArrayTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelArrayTests.cs
@@ -294,6 +294,15 @@ public class ExcelArrayTests
         Assert.Equal(1.0, (double)list[0]);
     }
 
+    [Fact]
+    public void ForEach_ExecutesActionPerElement()
+    {
+        var arr = MakeSingleColumn();
+        var sum = 0.0;
+        arr.ForEach(el => sum += (double)el);
+        Assert.Equal(6.0, sum);
+    }
+
     // --- SelectMany ---
 
     [Fact]

--- a/formula-boss.Runtime.Tests/RowCollectionTests.cs
+++ b/formula-boss.Runtime.Tests/RowCollectionTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace FormulaBoss.Runtime.Tests;
@@ -59,5 +61,30 @@ public class RowCollectionTests
         var result = empty.Scan(0.0, (acc, r) => acc + (double)r[1]);
         var arr = (object?[,])result.ToResult();
         Assert.Equal(0, arr.GetLength(0));
+    }
+
+    [Fact]
+    public void Row_Foreach_EnumeratesColumnValues()
+    {
+        var row = new Row(new object?[] { "A", 10.0, true }, ColumnMap);
+        var values = new List<object?>();
+        foreach (var col in row)
+        {
+            values.Add(col.Value);
+        }
+
+        Assert.Equal(3, values.Count);
+        Assert.Equal("A", values[0]);
+        Assert.Equal(10.0, values[1]);
+        Assert.Equal(true, values[2]);
+    }
+
+    [Fact]
+    public void Row_LinqToList_Works()
+    {
+        var row = new Row(new object?[] { 1.0, 2.0, 3.0 }, null);
+        var list = row.ToList();
+        Assert.Equal(3, list.Count);
+        Assert.Equal(2.0, (double)list[1]);
     }
 }

--- a/formula-boss.Runtime/ExcelValue.cs
+++ b/formula-boss.Runtime/ExcelValue.cs
@@ -105,6 +105,15 @@ public abstract class ExcelValue : IExcelRange, IEnumerable<ExcelValue>, ICompar
     public abstract IExcelRange Distinct();
 
     /// <inheritdoc />
+    public void ForEach(Action<ExcelValue> action)
+    {
+        foreach (var el in this)
+        {
+            action(el);
+        }
+    }
+
+    /// <inheritdoc />
     public abstract dynamic Aggregate(dynamic seed, Func<dynamic, dynamic, dynamic> func);
 
     /// <inheritdoc />

--- a/formula-boss.Runtime/IExcelRange.cs
+++ b/formula-boss.Runtime/IExcelRange.cs
@@ -86,6 +86,10 @@ public interface IExcelRange
     /// <summary>Returns distinct elements (compared by string representation).</summary>
     IExcelRange Distinct();
 
+    /// <summary>Executes an action for each element in the range.</summary>
+    /// <param name="action">The action to perform on each element.</param>
+    void ForEach(Action<ExcelValue> action);
+
     /// <summary>Applies an accumulator function over the elements, returning the final result.</summary>
     /// <param name="seed">The initial accumulator value.</param>
     /// <param name="func">A function that takes (accumulator, element) and returns the new accumulator.</param>

--- a/formula-boss.Runtime/Row.cs
+++ b/formula-boss.Runtime/Row.cs
@@ -1,9 +1,10 @@
-﻿using System.Dynamic;
+﻿using System.Collections;
+using System.Dynamic;
 
 namespace FormulaBoss.Runtime;
 
 /// <summary>Represents a single row from an Excel range, with column access via indexer or dynamic member syntax.</summary>
-public class Row : DynamicObject
+public class Row : DynamicObject, IEnumerable<ColumnValue>
 {
     private readonly Dictionary<string, int>? _columnMap;
     private readonly object?[] _values;
@@ -49,6 +50,17 @@ public class Row : DynamicObject
 
     /// <summary>Gets the number of columns in this row.</summary>
     public int ColumnCount => _values.Length;
+
+    /// <summary>Returns an enumerator that iterates over the column values in this row.</summary>
+    public IEnumerator<ColumnValue> GetEnumerator()
+    {
+        for (var i = 0; i < _values.Length; i++)
+        {
+            yield return MakeColumnValue(i);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <summary>
     ///     Converts a Row to an ExcelArray (1 row × N columns) so it can be returned


### PR DESCRIPTION
## Summary

- Adds `IEnumerable<ExcelValue>` to `ExcelValue` base class — enables `foreach` over any range
  - `ExcelArray`: delegates to `ElementWise()` (row-major)
  - `ExcelScalar`: yields self
- Adds `ForEach(Action<ExcelValue>)` instance method to `ExcelValue`/`IExcelRange`
- Adds `IEnumerable<ColumnValue>` to `Row` — enables `foreach` over a row's column values
- AddIn test proving `foreach` works end-to-end in a live Excel cell

## Test plan

- [x] 194 Runtime unit tests pass (7 new: foreach array/scalar/multi-column, LINQ ToList, ForEach, Row foreach/ToList)
- [x] 35 AddIn integration tests pass (1 new: `Foreach_SumsRange`)
- [x] 34 pipeline integration tests pass
- [x] 381 formula-boss.Tests pass

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)