### PR TITLE
Add crash resilience: global exception guards and error logging

### DIFF
--- a/formula-boss/AddIn.cs
+++ b/formula-boss/AddIn.cs
@@ -51,6 +51,10 @@ public sealed class AddIn : IExcelAddIn, IDisposable
     {
         _instance = this;
 
+        // Install global exception handlers as early as possible — before any other
+        // initialization that might throw on background threads.
+        CrashGuard.InstallGlobalHandlers();
+
         try
         {
             // AutoClose is NOT called when Excel shuts down — only when the
@@ -183,7 +187,7 @@ public sealed class AddIn : IExcelAddIn, IDisposable
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"AddIn.AutoOpen error: {ex}");
+            CrashGuard.Log("AddIn.AutoOpen", ex);
         }
     }
 
@@ -209,7 +213,7 @@ public sealed class AddIn : IExcelAddIn, IDisposable
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"InitializeInterception error: {ex}");
+            CrashGuard.Log("InitializeInterception", ex);
         }
     }
 

--- a/formula-boss/Commands/ShowFloatingEditorCommand.cs
+++ b/formula-boss/Commands/ShowFloatingEditorCommand.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using System.Windows.Interop;
 using System.Windows.Threading;
 
@@ -147,7 +146,7 @@ public static class ShowFloatingEditorCommand
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"ShowFloatingEditor error: {ex.Message}");
+            CrashGuard.Log("ShowFloatingEditor", ex);
         }
         finally
         {
@@ -210,7 +209,7 @@ public static class ShowFloatingEditorCommand
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"CaptureTargetCellPosition error: {ex}");
+            CrashGuard.Log("CaptureTargetCellPosition", ex);
             _targetCellScreenLeft = 0;
             _targetCellScreenTop = 0;
         }
@@ -237,6 +236,15 @@ public static class ShowFloatingEditorCommand
             _window = new FloatingEditorWindow();
             _window.FormulaApplied += OnFormulaApplied;
             _windowDispatcher = Dispatcher.CurrentDispatcher;
+
+            // Catch any unhandled exception on the WPF dispatcher thread
+            // so it doesn't crash the background thread (and potentially Excel).
+            _windowDispatcher.UnhandledException += (_, args) =>
+            {
+                CrashGuard.Log("WPF Dispatcher.UnhandledException", args.Exception);
+                args.Handled = true;
+            };
+
             readyEvent.Set();
 
             Dispatcher.Run();
@@ -293,7 +301,7 @@ public static class ShowFloatingEditorCommand
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"OnFormulaApplied error: {ex.Message}");
+                CrashGuard.Log("OnFormulaApplied", ex);
             }
             finally
             {
@@ -333,7 +341,7 @@ public static class ShowFloatingEditorCommand
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"PlayChompAnimation error: {ex.Message}");
+            CrashGuard.Log("PlayChompAnimation", ex);
             return null;
         }
     }

--- a/formula-boss/CrashGuard.cs
+++ b/formula-boss/CrashGuard.cs
@@ -1,0 +1,110 @@
+using System.Diagnostics;
+using System.IO;
+
+namespace FormulaBoss;
+
+/// <summary>
+///     Global exception guards and logging to prevent the add-in from crashing Excel.
+///     All unhandled exceptions are caught, logged, and swallowed.
+/// </summary>
+internal static class CrashGuard
+{
+    private static readonly object Lock = new();
+    private static string? _logPath;
+
+    /// <summary>
+    ///     Absolute path to the current log file.
+    /// </summary>
+    public static string LogPath => _logPath ??= InitLogPath();
+
+    /// <summary>
+    ///     Installs global exception handlers that prevent unhandled exceptions
+    ///     from propagating to Excel and crashing the host process.
+    ///     Must be called once, as early as possible in <see cref="AddIn.AutoOpen" />.
+    /// </summary>
+    public static void InstallGlobalHandlers()
+    {
+        // Catch exceptions on threads that have no try/catch (thread pool, manual threads).
+        // IsTerminating is true for .NET Framework but always false for .NET Core/5+;
+        // either way we log and move on.
+        AppDomain.CurrentDomain.UnhandledException += (_, args) =>
+        {
+            Log("AppDomain.UnhandledException", args.ExceptionObject as Exception);
+        };
+
+        // Catch unobserved Task exceptions (fire-and-forget async, un-awaited tasks).
+        // SetObserved() prevents the runtime from tearing down the process.
+        TaskScheduler.UnobservedTaskException += (_, args) =>
+        {
+            Log("TaskScheduler.UnobservedTaskException", args.Exception);
+            args.SetObserved();
+        };
+    }
+
+    /// <summary>
+    ///     Logs an error with context to the log file and Debug output.
+    /// </summary>
+    public static void Log(string context, Exception? ex)
+    {
+        var message = ex != null
+            ? $"{context}: {ex}"
+            : $"{context}: (no exception object)";
+
+        Debug.WriteLine($"[CrashGuard] {message}");
+
+        try
+        {
+            lock (Lock)
+            {
+                File.AppendAllText(LogPath,
+                    $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {message}{Environment.NewLine}");
+            }
+        }
+        catch
+        {
+            // Last resort — can't even write to log. Nothing more we can do.
+        }
+    }
+
+    /// <summary>
+    ///     Logs a plain message (no exception) to the log file and Debug output.
+    /// </summary>
+    public static void Log(string message)
+    {
+        Debug.WriteLine($"[CrashGuard] {message}");
+
+        try
+        {
+            lock (Lock)
+            {
+                File.AppendAllText(LogPath,
+                    $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {message}{Environment.NewLine}");
+            }
+        }
+        catch
+        {
+            // Last resort
+        }
+    }
+
+    private static string InitLogPath()
+    {
+        // Place log file in %LOCALAPPDATA%/FormulaBoss/ so it survives add-in updates
+        // and is accessible even when the XLL directory is read-only.
+        var dir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "FormulaBoss");
+
+        try
+        {
+            Directory.CreateDirectory(dir);
+        }
+        catch
+        {
+            // Fall back to temp directory if we can't create the folder
+            dir = Path.GetTempPath();
+        }
+
+        return Path.Combine(dir, "formula-boss.log");
+    }
+}

--- a/formula-boss/Interception/FormulaInterceptor.cs
+++ b/formula-boss/Interception/FormulaInterceptor.cs
@@ -108,13 +108,13 @@ public class FormulaInterceptor : IDisposable
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine($"ProcessCell error for {address}: {ex.Message}");
+                    CrashGuard.Log($"ProcessCell ({address})", ex);
                 }
             });
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"OnSheetChange error: {ex.Message}");
+            CrashGuard.Log("OnSheetChange", ex);
         }
         finally
         {
@@ -155,7 +155,7 @@ public class FormulaInterceptor : IDisposable
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"ProcessCell error: {ex.Message}");
+            CrashGuard.Log("ProcessCell", ex);
             SetCellError(cell, $"Internal error: {ex.Message}");
         }
     }
@@ -364,7 +364,7 @@ public class FormulaInterceptor : IDisposable
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Failed to write formula: {ex.Message}");
+            CrashGuard.Log("WriteFormula", ex);
             SetCellError(cell, $"Could not write formula: {ex.Message}");
         }
     }

--- a/formula-boss/UI/EditorBehaviorHandler.cs
+++ b/formula-boss/UI/EditorBehaviorHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Input;
 
 using ICSharpCode.AvalonEdit;
@@ -138,7 +137,7 @@ internal class EditorBehaviorHandler
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"OnTextEntering error: {ex.Message}");
+            CrashGuard.Log("OnTextEntering", ex);
         }
     }
 
@@ -180,7 +179,7 @@ internal class EditorBehaviorHandler
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"OnTextEntered error: {ex.Message}");
+            CrashGuard.Log("OnTextEntered", ex);
         }
     }
 
@@ -298,7 +297,7 @@ internal class EditorBehaviorHandler
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"OnPreviewKeyDown error: {ex.Message}");
+            CrashGuard.Log("OnPreviewKeyDown", ex);
         }
     }
 
@@ -901,9 +900,9 @@ internal class EditorBehaviorHandler
                 doc.Replace(prevLine.Offset, prevLine.Length, "");
             }
         }
-        catch (ArgumentOutOfRangeException ex)
+        catch (Exception ex)
         {
-            Debug.WriteLine($"OnCaretPositionChanged error: {ex.Message}");
+            CrashGuard.Log("OnCaretPositionChanged", ex);
         }
     }
 

--- a/formula-boss/UI/ErrorHighlighter.cs
+++ b/formula-boss/UI/ErrorHighlighter.cs
@@ -127,6 +127,10 @@ internal sealed class ErrorHighlighter : IBackgroundRenderer
         {
             // Expected when user types quickly
         }
+        catch (Exception ex)
+        {
+            CrashGuard.Log("ErrorHighlighter.OnDebounceTimerTick", ex);
+        }
     }
 
     private async Task UpdateErrorsAsync(CancellationToken ct)

--- a/formula-boss/UI/FloatingEditorWindow.xaml.cs
+++ b/formula-boss/UI/FloatingEditorWindow.xaml.cs
@@ -148,6 +148,22 @@ public partial class FloatingEditorWindow
 
     private async void ShowCompletion()
     {
+        try
+        {
+            await ShowCompletionCore();
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when user types quickly
+        }
+        catch (Exception ex)
+        {
+            CrashGuard.Log("ShowCompletion", ex);
+        }
+    }
+
+    private async Task ShowCompletionCore()
+    {
         // Don't open a second window
         if (_completionWindow != null)
         {
@@ -164,18 +180,8 @@ public partial class FloatingEditorWindow
         var textUpToCaret = FormulaEditor.Document.GetText(0, FormulaEditor.CaretOffset);
         var fullText = FormulaEditor.Text;
 
-        IReadOnlyList<CompletionData> items;
-        bool isBracketContext;
-
-        try
-        {
-            (items, isBracketContext) = await _completionProvider!.GetCompletionsAsync(
-                textUpToCaret, fullText, Metadata, ct);
-        }
-        catch (OperationCanceledException)
-        {
-            return;
-        }
+        var (items, isBracketContext) = await _completionProvider!.GetCompletionsAsync(
+            textUpToCaret, fullText, Metadata, ct);
 
         if (ct.IsCancellationRequested || items.Count == 0)
         {
@@ -245,6 +251,22 @@ public partial class FloatingEditorWindow
 
     private async void ShowSignatureHelp()
     {
+        try
+        {
+            await ShowSignatureHelpCore();
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when user types quickly
+        }
+        catch (Exception ex)
+        {
+            CrashGuard.Log("ShowSignatureHelp", ex);
+        }
+    }
+
+    private async Task ShowSignatureHelpCore()
+    {
         EnsureWorkspace();
 
         _signatureHelpCts?.Cancel();
@@ -254,17 +276,8 @@ public partial class FloatingEditorWindow
         var textUpToCaret = FormulaEditor.Document.GetText(0, FormulaEditor.CaretOffset);
         var fullText = FormulaEditor.Text;
 
-        SignatureHelpModel? model;
-
-        try
-        {
-            model = await _signatureHelpProvider!.GetSignatureHelpAsync(
-                textUpToCaret, fullText, Metadata, ct);
-        }
-        catch (OperationCanceledException)
-        {
-            return;
-        }
+        var model = await _signatureHelpProvider!.GetSignatureHelpAsync(
+            textUpToCaret, fullText, Metadata, ct);
 
         if (ct.IsCancellationRequested)
         {


### PR DESCRIPTION
## Summary
- Adds `CrashGuard` class with persistent file logging to `%LOCALAPPDATA%/FormulaBoss/formula-boss.log`
- Installs `AppDomain.UnhandledException`, `TaskScheduler.UnobservedTaskException`, and WPF `Dispatcher.UnhandledException` handlers to catch and swallow unhandled exceptions on all threads
- Wraps `async void` methods (`ShowCompletion`, `ShowSignatureHelp`, `OnDebounceTimerTick`) with try-catch guards to prevent unobserved exceptions from crashing the WPF dispatcher thread
- Replaces `Debug.WriteLine` error logging with `CrashGuard.Log` across all entry points so errors are visible in Release builds

## Test plan
- [x] All 644 tests pass (194 Runtime + 381 Unit + 34 Integration + 35 AddIn)
- [ ] Manual: verify log file is created at `%LOCALAPPDATA%/FormulaBoss/formula-boss.log` after loading add-in
- [ ] Manual: inject a `throw` in `OnSheetChange` — confirm Excel doesn't crash and error appears in log
- [ ] Manual: inject a `throw` in `ShowCompletion` — confirm editor stays functional and error appears in log

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)