### PR TITLE
Scan repo history for leaked secrets

### DIFF
--- a/docs/assembly-identity-investigation.md
+++ b/docs/assembly-identity-investigation.md
@@ -54,11 +54,11 @@ Each test was in a separate class to isolate JIT failures.
 
 **FBTEST1 (assembly locations):**
 ```
-Runtime: C:\Users\trjac\Repositories\taglo-formula-boss\formula-boss\bin\Debug\net6.0-windows\FormulaBoss.Runtime.dll
+Runtime: <repo>\formula-boss\bin\Debug\net6.0-windows\FormulaBoss.Runtime.dll
   FullName: FormulaBoss.Runtime, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
 ExcelDNA: (empty location)
   FullName: ExcelDna.Integration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f225e9659857edbe
-Host: C:\Users\trjac\Repositories\taglo-formula-boss\formula-boss\bin\Debug\net6.0-windows\formula-boss.dll
+Host: <repo>\formula-boss\bin\Debug\net6.0-windows\formula-boss.dll
   FullName: formula-boss, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
 ```
 


### PR DESCRIPTION
Closes #135

## Summary

- Scanned full git history for leaked secrets (API keys, passwords, tokens, private keys, certificates, connection strings, signing keys) — **none found**
- Found and replaced 2 personal path references (`C:\Users\trjac\...`) in `docs/assembly-identity-investigation.md` with `<repo>\...` placeholders
- Verified `.gitignore` covers sensitive file types (`.pfx`, `.env`, secrets, etc.)

## Scan methodology

Searched the complete git history (`git log --all -p`) for:
- `password`, `api_key`/`apikey`/`api-key`, `secret_key`/`secretkey`
- `token`, `bearer`, `authorization`
- `connectionstring`, `connection_string`
- `BEGIN PRIVATE KEY`, `BEGIN RSA`, `BEGIN CERTIFICATE`
- OpenAI/Anthropic-style keys (`sk-...`), AWS keys (`AKIA...`), GitHub PATs (`ghp_...`, `github_pat_...`)
- Sensitive file types ever added (`.pfx`, `.p12`, `.key`, `.pem`, `.env`, `.snk`)
- Personal paths (`C:\Users\trjac`)

## Result

The repo history is clean. The only finding was personal filesystem paths in diagnostic test output (now replaced).

## Test plan

- [x] `grep -r "C:\Users\trjac"` returns no matches in working tree
- [x] Verify doc still reads correctly after path replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)