### PR TITLE
Repo hygiene: branch protection, issue templates, topics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report something that isn't working correctly
+title: ''
+labels: bug, status: backlog
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behaviour:
+1.
+2.
+3.
+
+**Expected behaviour**
+What you expected to happen.
+
+**Screenshots / error messages**
+If applicable, add screenshots or paste error messages.
+
+**Environment**
+- Excel version: [e.g. Microsoft 365, Excel 2021]
+- OS: [e.g. Windows 11]
+- Formula Boss version: [e.g. from About or the XLL filename]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement, status: backlog
+assignees: ''
+---
+
+**Problem or motivation**
+What problem does this solve, or what would it enable?
+
+**Proposed solution**
+Describe what you'd like to happen.
+
+**Alternatives considered**
+Any other approaches you've thought about.
+
+**Additional context**
+Any other information, screenshots, or examples.


### PR DESCRIPTION
Closes #136

## Summary

- **Branch protection on main** — created ruleset requiring 1 PR approval and blocking force-push
- **Issue templates** — added bug report and feature request templates in `.github/ISSUE_TEMPLATE/`
- **Repo metadata** — set description and topic tags (excel, exceldna, add-in, csharp, competitive-excel)

## Test plan

- [x] Repo description and topics visible on GitHub repo page
- [x] Branch protection ruleset active (verified via API response)
- [x] Issue templates appear when creating a new issue
- [x] Direct push to main is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)