### PR TITLE
Add Ctrl+MouseWheel zoom to floating editor

### DIFF
--- a/formula-boss/UI/EditorSettings.cs
+++ b/formula-boss/UI/EditorSettings.cs
@@ -9,6 +9,7 @@ public class EditorSettings
     public double Width { get; set; } = 500;
     public double Height { get; set; } = 300;
     public int IndentSize { get; set; } = 2;
+    public double FontSize { get; set; } = 13;
 
     private static string SettingsDirectory =>
         Path.Combine(

--- a/formula-boss/UI/FloatingEditorWindow.xaml
+++ b/formula-boss/UI/FloatingEditorWindow.xaml
@@ -84,7 +84,6 @@
         <!-- Editor fills remaining space -->
         <avalonedit:TextEditor x:Name="FormulaEditor"
                                FontFamily="Consolas"
-                               FontSize="13"
                                ShowLineNumbers="True"
                                HorizontalScrollBarVisibility="Auto"
                                VerticalScrollBarVisibility="Auto"

--- a/formula-boss/UI/FloatingEditorWindow.xaml.cs
+++ b/formula-boss/UI/FloatingEditorWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
 using System.Xml;
@@ -37,9 +38,13 @@ public partial class FloatingEditorWindow
         // Load logo into the bottom bar
         LoadLogo();
 
-        // Apply saved size
+        // Apply saved size and font size
         Width = _settings.Width;
         Height = _settings.Height;
+        FormulaEditor.FontSize = _settings.FontSize;
+
+        // Ctrl+MouseWheel zoom
+        FormulaEditor.PreviewMouseWheel += OnEditorPreviewMouseWheel;
 
         // Load syntax highlighting
         LoadSyntaxHighlighting();
@@ -325,6 +330,25 @@ public partial class FloatingEditorWindow
             _settings.Save();
             _sizeChanged = false;
         }
+    }
+
+    private void OnEditorPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        if (Keyboard.Modifiers != ModifierKeys.Control)
+        {
+            return;
+        }
+
+        e.Handled = true;
+
+        const double minFontSize = 8;
+        const double maxFontSize = 30;
+        var delta = e.Delta > 0 ? 1.0 : -1.0;
+        var newSize = Math.Clamp(FormulaEditor.FontSize + delta, minFontSize, maxFontSize);
+
+        FormulaEditor.FontSize = newSize;
+        _settings.FontSize = newSize;
+        _settings.Save();
     }
 
     private void ApplyButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

- Adds Ctrl+MouseWheel zoom to the AvalonEdit text editor (8pt–30pt range)
- Persists zoom level in the existing `EditorSettings` JSON across sessions
- Removes hardcoded `FontSize="13"` from XAML; default preserved via `EditorSettings.FontSize = 13`

Closes #167

## Test plan

- [x] Open editor, Ctrl+scroll up → font gets larger
- [x] Ctrl+scroll down → font gets smaller
- [x] Font doesn't go below 8pt or above 30pt
- [x] Close and reopen editor → zoom level preserved
- [x] Line numbers, bracket highlighting, error squiggles all render correctly at different zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)