### PR TITLE
Show current cell address in editor title bar

### DIFF
--- a/formula-boss/Commands/ShowFloatingEditorCommand.cs
+++ b/formula-boss/Commands/ShowFloatingEditorCommand.cs
@@ -92,6 +92,7 @@ public static class ShowFloatingEditorCommand
             // Capture worksheet on the Excel thread (not inside the WPF dispatcher)
             // to avoid cross-apartment COM proxy complications
             worksheet = cell.Worksheet;
+            var sheetName = worksheet.Name as string;
 
             // Capture cell screen position for animation placement
             CaptureTargetCellPosition(cell);
@@ -119,6 +120,7 @@ public static class ShowFloatingEditorCommand
                         _targetWorksheet = worksheet;
                         worksheet = null; // Ownership transferred
                         _targetAddress = currentAddress;
+                        _window.UpdateTitle(sheetName, currentAddress);
                         _window.Metadata = metadata;
                         _window.FormulaText = editorContent;
                     }
@@ -130,6 +132,7 @@ public static class ShowFloatingEditorCommand
                     _targetWorksheet = worksheet;
                     worksheet = null; // Ownership transferred
                     _targetAddress = currentAddress;
+                    _window.UpdateTitle(sheetName, currentAddress);
                     _window.Metadata = metadata;
                     _window.FormulaText = editorContent;
 

--- a/formula-boss/UI/FloatingEditorWindow.xaml.cs
+++ b/formula-boss/UI/FloatingEditorWindow.xaml.cs
@@ -124,6 +124,21 @@ public partial class FloatingEditorWindow
         set => FormulaEditor.Text = value;
     }
 
+    /// <summary>
+    ///     Updates the title bar to show the cell being edited.
+    /// </summary>
+    public void UpdateTitle(string? sheetName, string? address)
+    {
+        if (string.IsNullOrEmpty(sheetName) || string.IsNullOrEmpty(address))
+        {
+            Title = "Formula Boss";
+            return;
+        }
+
+        var cleanAddress = address.Replace("$", "");
+        Title = $"Formula Boss \u2014 {sheetName}!{cleanAddress}";
+    }
+
     public event EventHandler<string>? FormulaApplied;
 
     private void LoadLogo()


### PR DESCRIPTION
## Summary
- Display sheet-qualified cell address in the floating editor title bar (e.g. "Formula Boss — Sheet2!D15")
- Title updates when re-targeting a different cell while editor is open
- `$` signs stripped from addresses for readability

Closes #169

## Test plan
- [x] All 644 tests pass (unit, integration, and addin tests)
- [x] Open editor on a cell → title shows "Formula Boss — Sheet1!A1" (or equivalent)
- [x] With editor open, trigger on a different cell → title updates
- [x] With editor open, trigger on same cell → editor hides (toggle behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)