### PR TITLE
Add release signing docs for Sectigo certificate

### DIFF
--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,35 @@
+# Release Signing
+
+Sign the `.xll` with the Sectigo code-signing certificate before publishing a GitHub Release.
+
+## Prerequisites
+
+- **signtool.exe** — ships with Visual Studio (ClickOnce SDK):
+  `C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\signtool.exe`
+- **Sectigo PFX file** — not committed to the repo (`.gitignore` excludes `*.pfx`)
+
+## Steps
+
+1. Build in Release configuration:
+
+   ```
+   dotnet build formula-boss/formula-boss.slnx -c Release
+   ```
+
+2. Sign the 64-bit XLL:
+
+   ```
+   signtool sign /f "path\to\certificate.pfx" /p "pfx-password" /fd sha256 /tr http://timestamp.sectigo.com /td sha256 formula-boss\bin\Release\net6.0-windows\formula-boss64.xll
+   ```
+
+3. Verify the signature:
+
+   ```
+   signtool verify /pa formula-boss\bin\Release\net6.0-windows\formula-boss64.xll
+   ```
+
+## Notes
+
+- The `/tr` and `/td` flags add an RFC 3161 timestamp so the signature remains valid after the certificate expires.
+- Only `formula-boss64.xll` needs signing — it's the native shim that Windows evaluates for SmartScreen. The managed DLLs it loads are not checked independently.
+- The PFX file and password must never be committed to source control.


### PR DESCRIPTION
## Summary

- Adds `docs/release-signing.md` documenting the manual signing step for releases using the Sectigo PFX certificate and `signtool.exe`

Closes #132

## Test plan

- [x] Tim follows the steps to sign the .xll with the Sectigo cert
- [x] Signed .xll passes `signtool verify /pa`
- [x] Signed .xll passes SmartScreen on a fresh machine (#134)

🤖 Generated with [Claude Code](https://claude.com/claude-code)