### PR TITLE
Fix ResultConverter to unwrap Cell, IEnumerable<Cell>, and single Row

### DIFF
--- a/formula-boss.AddinTests/PipelineTests.cs
+++ b/formula-boss.AddinTests/PipelineTests.cs
@@ -1146,6 +1146,91 @@ public class PipelineTests
     }
 
     [Fact]
+    public void CellsWhereBold_ReturnsValues()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            TestUtilities.SetCellValue(ws, "A1", 10.0);
+            TestUtilities.SetCellValue(ws, "A2", 20.0);
+            TestUtilities.SetCellValue(ws, "A3", 30.0);
+            TestUtilities.SetCellValue(ws, "A4", 40.0);
+
+            // Bold A2 and A4
+            TestUtilities.SetCellBold(ws, "A2", true);
+            TestUtilities.SetCellBold(ws, "A4", true);
+
+            TestUtilities.EnterBacktickFormula(ws, "B1", "=`A1:A4.Cells.Where(c => c.Bold)`");
+
+            var result = TestUtilities.WaitForResult(ws, "B1", _output);
+
+            _output.WriteLine($"B1 formula: {TestUtilities.GetCellFormula(ws, "B1")}");
+            _output.WriteLine($"B1={TestUtilities.GetCellValue(ws, "B1")}, B2={TestUtilities.GetCellValue(ws, "B2")}");
+            _output.WriteLine($"B1 comment: {TestUtilities.GetCellComment(ws, "B1")}");
+
+            Assert.NotNull(result);
+            Assert.Equal(20.0, Convert.ToDouble(TestUtilities.GetCellValue(ws, "B1")));
+            Assert.Equal(40.0, Convert.ToDouble(TestUtilities.GetCellValue(ws, "B2")));
+        }
+        finally
+        {
+            TestUtilities.CleanupWorksheet(ws);
+        }
+    }
+
+    [Fact]
+    public void SingleRow_ReturnsHorizontalArray()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            TestUtilities.SetCellValue(ws, "A1", "Name");
+            TestUtilities.SetCellValue(ws, "B1", "Amount");
+            TestUtilities.SetCellValue(ws, "A2", "Alice");
+            TestUtilities.SetCellValue(ws, "B2", 100.0);
+            TestUtilities.SetCellValue(ws, "A3", "Bob");
+            TestUtilities.SetCellValue(ws, "B3", 200.0);
+
+            var range = ws.Range["A1:B3"];
+            var tables = ws.ListObjects;
+            try
+            {
+                var table = tables.Add(1, range, Type.Missing, 1);
+                try
+                {
+                    var tableName = (string)table.Name;
+
+                    TestUtilities.EnterBacktickFormula(ws, "D1",
+                        $"=`{tableName}.Rows.First()`");
+
+                    var result = TestUtilities.WaitForResult(ws, "D1", _output);
+
+                    _output.WriteLine($"D1 formula: {TestUtilities.GetCellFormula(ws, "D1")}");
+                    _output.WriteLine($"D1={TestUtilities.GetCellValue(ws, "D1")}, E1={TestUtilities.GetCellValue(ws, "E1")}");
+                    _output.WriteLine($"D1 comment: {TestUtilities.GetCellComment(ws, "D1")}");
+
+                    Assert.NotNull(result);
+                    Assert.Equal("Alice", TestUtilities.GetCellValue(ws, "D1"));
+                    Assert.Equal(100.0, Convert.ToDouble(TestUtilities.GetCellValue(ws, "E1")));
+                }
+                finally
+                {
+                    System.Runtime.InteropServices.Marshal.ReleaseComObject(table);
+                }
+            }
+            finally
+            {
+                System.Runtime.InteropServices.Marshal.ReleaseComObject(tables);
+                System.Runtime.InteropServices.Marshal.ReleaseComObject(range);
+            }
+        }
+        finally
+        {
+            TestUtilities.CleanupWorksheet(ws);
+        }
+    }
+
+    [Fact]
     public void CrossSheetRangeRef_SumsCorrectly()
     {
         // Create a second worksheet with data, then reference it from the first

--- a/formula-boss.Runtime.Tests/ResultConverterTests.cs
+++ b/formula-boss.Runtime.Tests/ResultConverterTests.cs
@@ -141,4 +141,57 @@ public class ResultConverterTests
         Assert.Equal(1, arr.GetLength(0));
         Assert.Equal(42.0, arr[0, 0]);
     }
+
+    [Fact]
+    public void Convert_Cell_UnwrapsToValue()
+    {
+        var result = ResultConverter.Convert(new Cell { Value = 42.0 });
+        Assert.Equal(42.0, result);
+    }
+
+    [Fact]
+    public void Convert_Cell_NullValueReturnsEmpty()
+    {
+        var result = ResultConverter.Convert(new Cell { Value = null });
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void Convert_EnumerableCell_ReturnsVerticalArray()
+    {
+        IEnumerable<Cell> cells = new[]
+        {
+            new Cell { Value = 10.0 },
+            new Cell { Value = 20.0 },
+            new Cell { Value = 30.0 }
+        };
+
+        var result = ResultConverter.Convert(cells);
+        var arr = Assert.IsType<object?[,]>(result);
+        Assert.Equal(3, arr.GetLength(0));
+        Assert.Equal(1, arr.GetLength(1));
+        Assert.Equal(10.0, arr[0, 0]);
+        Assert.Equal(20.0, arr[1, 0]);
+        Assert.Equal(30.0, arr[2, 0]);
+    }
+
+    [Fact]
+    public void Convert_EnumerableCell_EmptyReturnsEmpty()
+    {
+        IEnumerable<Cell> cells = Array.Empty<Cell>();
+        var result = ResultConverter.Convert(cells);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void Convert_SingleRow_ReturnsHorizontalArray()
+    {
+        var row = new Row(["Alice", 30.0], null);
+        var result = ResultConverter.Convert(row);
+        var arr = Assert.IsType<object?[,]>(result);
+        Assert.Equal(1, arr.GetLength(0));
+        Assert.Equal(2, arr.GetLength(1));
+        Assert.Equal("Alice", arr[0, 0]);
+        Assert.Equal(30.0, arr[0, 1]);
+    }
 }

--- a/formula-boss.Runtime/ResultConverter.cs
+++ b/formula-boss.Runtime/ResultConverter.cs
@@ -30,6 +30,23 @@ public static class ResultConverter
             return colVal.Value ?? string.Empty;
         }
 
+        if (result is Cell cell)
+        {
+            return cell.Value ?? string.Empty;
+        }
+
+        if (result is Row singleRow)
+        {
+            var cols = singleRow.ColumnCount;
+            var arr = new object?[1, cols];
+            for (var c = 0; c < cols; c++)
+            {
+                arr[0, c] = singleRow[c].Value;
+            }
+
+            return arr;
+        }
+
         if (result is bool or int or double or string)
         {
             return result;
@@ -85,6 +102,23 @@ public static class ResultConverter
                 {
                     arr[r, c] = rowList[r][c].Value;
                 }
+
+            return arr;
+        }
+
+        if (result is IEnumerable<Cell> cells)
+        {
+            var list = cells.ToList();
+            if (list.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var arr = new object?[list.Count, 1];
+            for (var r = 0; r < list.Count; r++)
+            {
+                arr[r, 0] = list[r].Value;
+            }
 
             return arr;
         }


### PR DESCRIPTION
## Summary
- **`Cell`** results now unwrap to `.Value` (like `ColumnValue`)
- **`IEnumerable<Cell>`** (e.g. `.Cells.Where(c => c.Bold)`) produces a vertical array of values
- **Single `Row`** (e.g. `.Rows.First()`) produces a 1×N horizontal array

## Tests
- 5 new unit tests in `ResultConverterTests`
- 2 new AddIn integration tests: `CellsWhereBold_ReturnsValues`, `SingleRow_ReturnsHorizontalArray`
- All 37 AddIn tests pass, all 23 unit tests pass

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)