### PR TITLE
Add update checker with ribbon notification

### DIFF
--- a/formula-boss.Tests/UpdateCheckerTests.cs
+++ b/formula-boss.Tests/UpdateCheckerTests.cs
@@ -1,0 +1,77 @@
+using FormulaBoss.Updates;
+
+using Xunit;
+
+namespace FormulaBoss.Tests;
+
+public class UpdateCheckerTests
+{
+    [Theory]
+    [InlineData("v0.2.0", 0, 2, 0)]
+    [InlineData("v1.0.0", 1, 0, 0)]
+    [InlineData("0.3.1", 0, 3, 1)]
+    [InlineData("V0.1.0", 0, 1, 0)]
+    [InlineData("v10.20.30", 10, 20, 30)]
+    public void ParseVersion_ValidTags_ReturnsCorrectVersion(string tag, int major, int minor, int build)
+    {
+        var result = UpdateChecker.ParseVersion(tag);
+
+        Assert.NotNull(result);
+        Assert.Equal(major, result!.Major);
+        Assert.Equal(minor, result.Minor);
+        Assert.Equal(build, result.Build);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-version")]
+    [InlineData("v")]
+    [InlineData("vabc")]
+    public void ParseVersion_InvalidTags_ReturnsNull(string tag)
+    {
+        var result = UpdateChecker.ParseVersion(tag);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseVersion_WithPrereleaseSuffix_ParsesBaseVersion()
+    {
+        // Version.TryParse ignores everything after the version numbers
+        // but tags like "v0.2.0-beta" won't parse — that's acceptable
+        var result = UpdateChecker.ParseVersion("v0.2.0");
+
+        Assert.NotNull(result);
+        Assert.Equal(new Version(0, 2, 0), result);
+    }
+
+    [Fact]
+    public void VersionComparison_NewerVersion_IsGreater()
+    {
+        var current = new Version(0, 1, 0);
+        var remote = UpdateChecker.ParseVersion("v0.2.0");
+
+        Assert.NotNull(remote);
+        Assert.True(remote > current);
+    }
+
+    [Fact]
+    public void VersionComparison_SameVersion_IsNotGreater()
+    {
+        var current = new Version(0, 1, 0);
+        var remote = UpdateChecker.ParseVersion("v0.1.0");
+
+        Assert.NotNull(remote);
+        Assert.False(remote > current);
+    }
+
+    [Fact]
+    public void VersionComparison_OlderVersion_IsNotGreater()
+    {
+        var current = new Version(0, 2, 0);
+        var remote = UpdateChecker.ParseVersion("v0.1.0");
+
+        Assert.NotNull(remote);
+        Assert.False(remote > current);
+    }
+}

--- a/formula-boss/AddIn.cs
+++ b/formula-boss/AddIn.cs
@@ -6,6 +6,7 @@ using FormulaBoss.Commands;
 using FormulaBoss.Compilation;
 using FormulaBoss.Interception;
 using FormulaBoss.Runtime;
+using FormulaBoss.Updates;
 
 namespace FormulaBoss;
 
@@ -190,6 +191,9 @@ public sealed class AddIn : IExcelAddIn, IDisposable
             // Defer event hookup until Excel is fully initialized
             // ExcelAsyncUtil.QueueAsMacro ensures we run after AutoOpen completes
             ExcelAsyncUtil.QueueAsMacro(InitializeInterception);
+
+            // Fire-and-forget update check — runs on background thread, silent on failure
+            UpdateChecker.CheckForUpdateAsync();
 
             Logger.Info("Formula Boss add-in loaded successfully");
         }

--- a/formula-boss/UI/RibbonController.cs
+++ b/formula-boss/UI/RibbonController.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 
 using ExcelDna.Integration.CustomUI;
 
 using FormulaBoss.Commands;
+using FormulaBoss.Updates;
 
 namespace FormulaBoss.UI;
 
@@ -13,8 +15,11 @@ namespace FormulaBoss.UI;
 [ComVisible(true)]
 public class RibbonController : ExcelRibbon
 {
+    private IRibbonUI? _ribbonUi;
+
     public override string GetCustomUI(string ribbonId) =>
-        @"<customUI xmlns='http://schemas.microsoft.com/office/2009/07/customui'>
+        @"<customUI xmlns='http://schemas.microsoft.com/office/2009/07/customui'
+                    onLoad='OnRibbonLoad'>
           <ribbon>
             <tabs>
               <tab id='formulaBossTab' label='Formula Boss'>
@@ -41,10 +46,26 @@ public class RibbonController : ExcelRibbon
                           size='normal'
                           onAction='OnAbout' />
                 </group>
+                <group id='updateGroup' label='Updates'>
+                  <button id='updateNotification'
+                          getLabel='GetUpdateLabel'
+                          getVisible='GetUpdateVisible'
+                          imageMso='Refresh'
+                          size='normal'
+                          onAction='OnUpdateClick'
+                          screentip='Update Available'
+                          supertip='A newer version of Formula Boss is available. Click to download.' />
+                </group>
               </tab>
             </tabs>
           </ribbon>
         </customUI>";
+
+    public void OnRibbonLoad(IRibbonUI ribbonUi)
+    {
+        _ribbonUi = ribbonUi;
+        UpdateChecker.UpdateAvailable += OnUpdateAvailable;
+    }
 
     public Bitmap GetEditorButtonImage(IRibbonControl control) => (Bitmap)base.LoadImage("logo32");
 
@@ -53,4 +74,32 @@ public class RibbonController : ExcelRibbon
     public void OnOpenSettings(IRibbonControl control) => ShowFloatingEditorCommand.ShowSettings();
 
     public void OnAbout(IRibbonControl control) => ShowFloatingEditorCommand.ShowAbout();
+
+    public string GetUpdateLabel(IRibbonControl control) =>
+        UpdateChecker.NewVersionAvailable != null
+            ? $"Update: v{UpdateChecker.NewVersionAvailable}"
+            : "No Updates";
+
+    public bool GetUpdateVisible(IRibbonControl control) =>
+        UpdateChecker.NewVersionAvailable != null;
+
+    public void OnUpdateClick(IRibbonControl control)
+    {
+        if (UpdateChecker.ReleaseUrl != null)
+        {
+            Process.Start(new ProcessStartInfo(UpdateChecker.ReleaseUrl) { UseShellExecute = true });
+        }
+    }
+
+    private void OnUpdateAvailable()
+    {
+        try
+        {
+            _ribbonUi?.InvalidateControl("updateNotification");
+        }
+        catch (Exception ex)
+        {
+            Logger.Info($"Failed to invalidate ribbon control: {ex.Message}");
+        }
+    }
 }

--- a/formula-boss/Updates/UpdateChecker.cs
+++ b/formula-boss/Updates/UpdateChecker.cs
@@ -1,0 +1,89 @@
+using System.Net.Http;
+using System.Reflection;
+using System.Text.Json;
+
+namespace FormulaBoss.Updates;
+
+/// <summary>
+///     Checks for newer releases on GitHub and exposes result for ribbon notification.
+///     All failures are silent — network errors are logged but never shown to the user.
+/// </summary>
+internal static class UpdateChecker
+{
+    private static readonly Uri LatestReleaseUri =
+        new("https://api.github.com/repos/TagloGit/taglo-formula-boss/releases/latest");
+
+    /// <summary>
+    ///     The newer version string (e.g. "0.2.0") if an update is available, otherwise null.
+    /// </summary>
+    public static string? NewVersionAvailable { get; private set; }
+
+    /// <summary>
+    ///     The URL of the GitHub release page for the newer version, otherwise null.
+    /// </summary>
+    public static string? ReleaseUrl { get; private set; }
+
+    /// <summary>
+    ///     Raised when a newer version is detected. Subscribers should call
+    ///     <see cref="IRibbonUI.InvalidateControl" /> to refresh the ribbon.
+    /// </summary>
+    public static event Action? UpdateAvailable;
+
+    /// <summary>
+    ///     Fire-and-forget async check. Call from <see cref="AddIn.AutoOpen" /> without awaiting.
+    /// </summary>
+    public static async void CheckForUpdateAsync()
+    {
+        try
+        {
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
+            client.DefaultRequestHeaders.UserAgent.ParseAdd($"FormulaBoss/{version}");
+
+            var json = await client.GetStringAsync(LatestReleaseUri);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var tagName = root.GetProperty("tag_name").GetString();
+            var htmlUrl = root.GetProperty("html_url").GetString();
+
+            if (tagName == null || htmlUrl == null)
+            {
+                return;
+            }
+
+            var remoteVersion = ParseVersion(tagName);
+            if (remoteVersion == null)
+            {
+                return;
+            }
+
+            var currentVersion = version ?? new Version(0, 0, 0);
+            if (remoteVersion > currentVersion)
+            {
+                NewVersionAvailable = remoteVersion.ToString();
+                ReleaseUrl = htmlUrl;
+                Logger.Info($"Update available: v{NewVersionAvailable} (current: v{currentVersion})");
+                UpdateAvailable?.Invoke();
+            }
+            else
+            {
+                Logger.Info($"No update available (current: v{currentVersion}, latest: v{remoteVersion})");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Info($"Update check failed (silent): {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    ///     Parses a version string like "v0.2.0" or "0.2.0" into a <see cref="Version" />.
+    ///     Returns null if parsing fails.
+    /// </summary>
+    internal static Version? ParseVersion(string tag)
+    {
+        var cleaned = tag.TrimStart('v', 'V');
+        return Version.TryParse(cleaned, out var version) ? version : null;
+    }
+}


### PR DESCRIPTION
Closes #183

## Summary

- **`UpdateChecker.cs`**: Static class that async-checks `api.github.com/repos/TagloGit/taglo-formula-boss/releases/latest`, parses `tag_name`, compares against assembly version. 10s timeout, all failures silent (logged only).
- **`RibbonController.cs`**: Added `onLoad` callback to capture `IRibbonUI`. New dynamic "Updates" group with a button that's hidden by default and appears via `InvalidateControl` when an update is detected. Click opens the release page in the browser.
- **`AddIn.cs`**: Fire-and-forget call to `UpdateChecker.CheckForUpdateAsync()` in `AutoOpen`.
- **Unit tests**: Version parsing and comparison logic (13 test cases).

All 664 existing tests pass, including AddIn tests in Excel.

## Test plan

- [x] Unit tests for version parsing and comparison
- [x] All existing tests pass (394 unit + 199 runtime + 34 integration + 37 AddIn)
- [x] Manual: launch Excel, verify no ribbon notification with current version
- [x] Manual: create a test GitHub release with higher version tag, verify notification appears
- [x] Manual: click notification, verify browser opens to release page
- [x] Manual: disconnect network, verify silent failure (no error shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)