### PR TITLE
Add --admin flag to publish script merge

### DIFF
--- a/scripts/publish-release.ps1
+++ b/scripts/publish-release.ps1
@@ -362,6 +362,7 @@ Write-Step 9 "Merge version bump PR"
 gh pr merge $releaseBranch `
     --repo TagloGit/taglo-formula-boss `
     --squash `
+    --admin `
     --delete-branch
 if ($LASTEXITCODE -ne 0) { Write-Error "Failed to merge PR. Merge manually and re-run." }
 Write-Success "Version bump PR merged"


### PR DESCRIPTION
## Summary
- Adds `--admin` to `gh pr merge` so the version bump PR can merge without a review
- Fixes the script failing at the merge step after a successful build+sign

## Test plan
- [x] Run publish script end-to-end for next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)