### PR TITLE
Revert premature 0.1.1 version bump

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Version — single source of truth for all assemblies -->
-    <Version>0.1.1</Version>
+    <Version>0.1.0</Version>
 
     <!-- Enforce code style during build -->
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>


### PR DESCRIPTION
## Summary
- Reverts #194 which was accidentally merged during a failed publish script run
- Restores version to `0.1.0` in `Directory.Build.props`

🤖 Generated with [Claude Code](https://claude.com/claude-code)