### PR TITLE
Block install if Excel is running

### DIFF
--- a/installer/formula-boss.iss
+++ b/installer/formula-boss.iss
@@ -193,6 +193,37 @@ begin
   Result := OpenKeyName;
 end;
 
+function IsExcelRunning: Boolean;
+var
+  WMIService: Variant;
+  Processes: Variant;
+begin
+  try
+    WMIService := CreateOleObject('WbemScripting.SWbemLocator');
+    WMIService := WMIService.ConnectServer('.', 'root\cimv2');
+    Processes := WMIService.ExecQuery('SELECT Name FROM Win32_Process WHERE Name = "EXCEL.EXE"');
+    Result := (Processes.Count > 0);
+  except
+    // If WMI fails, fall back to assuming Excel is not running
+    Result := False;
+  end;
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  Result := '';
+  while IsExcelRunning do
+  begin
+    if MsgBox('Excel is currently running and must be closed before Formula Boss can be installed.' + #13#10 + #13#10 +
+              'Please close Excel and click OK to continue, or click Cancel to abort the installation.',
+              mbError, MB_OKCANCEL) = IDCANCEL then
+    begin
+      Result := 'Installation cancelled. Please close Excel and try again.';
+      Exit;
+    end;
+  end;
+end;
+
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 var
   I: Integer;


### PR DESCRIPTION
## Summary
- Adds a `PrepareToInstall` check that detects running Excel via WMI before file operations begin
- Loops with a clear prompt ("Please close Excel and click OK to continue") until Excel is closed or the user cancels
- Prevents the "Access is denied" error and avoids partial installs from skipped files

## Why not CloseApplications?
The existing `CloseApplications=yes` with `CloseApplicationsFilter=EXCEL.EXE` relies on Windows Restart Manager, which doesn't reliably detect XLL file locks. The explicit WMI check is more reliable.

## Test plan
- [x] Run installer with Excel open — verify prompt appears
- [x] Close Excel, click OK — install proceeds
- [x] Click Cancel — install aborts cleanly
- [x] Run installer with Excel closed — no prompt, installs normally

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)