### PR TITLE
Add issue template config to enable template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false`
- Should force GitHub to show the template chooser instead of a blank issue form

## Test plan
- [ ] Click "New issue" on the repo and verify the template chooser appears with "Bug report" and "Feature request" options

🤖 Generated with [Claude Code](https://claude.com/claude-code)