### PR TITLE
Re-enable blank issues in template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled: true


### PR DESCRIPTION
## Summary
- Sets `blank_issues_enabled: true` so the template chooser shows templates plus a blank issue option

## Test plan
- [x] Click "New issue" — should see Bug report, Feature request, and "Open a blank issue" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)