### PR TITLE
Fix InputDetector missing foreach/pattern/catch variables (#212)

### DIFF
--- a/formula-boss.Tests/InputDetectorTests.cs
+++ b/formula-boss.Tests/InputDetectorTests.cs
@@ -80,6 +80,33 @@ public class InputDetectorTests
         Assert.Equal(["a", "m", "z"], result.Parameters);
     }
 
+    [Fact]
+    public void Detect_ForEachVariable_NotParameter()
+    {
+        var result = _detector.Detect("{ foreach (var country in countries) { } return countries; }");
+
+        Assert.Equal(["countries"], result.Parameters);
+        Assert.DoesNotContain("country", result.Parameters);
+    }
+
+    [Fact]
+    public void Detect_PatternVariable_NotParameter()
+    {
+        var result = _detector.Detect("{ if (value is double d) return d; return 0; }");
+
+        Assert.Equal(["value"], result.Parameters);
+        Assert.DoesNotContain("d", result.Parameters);
+    }
+
+    [Fact]
+    public void Detect_CatchVariable_NotParameter()
+    {
+        var result = _detector.Detect("{ try { return tbl.Sum(); } catch (System.Exception ex) { return 0; } }");
+
+        Assert.Contains("tbl", result.Parameters);
+        Assert.DoesNotContain("ex", result.Parameters);
+    }
+
     #endregion
 
     #region Range Reference Detection

--- a/formula-boss/Transpilation/InputDetector.cs
+++ b/formula-boss/Transpilation/InputDetector.cs
@@ -251,6 +251,21 @@ public class InputDetector
             declaredLocals.Add(varDecl.Identifier.Text);
         }
 
+        foreach (var forEach in root.DescendantNodes().OfType<ForEachStatementSyntax>())
+        {
+            declaredLocals.Add(forEach.Identifier.Text);
+        }
+
+        foreach (var designation in root.DescendantNodes().OfType<SingleVariableDesignationSyntax>())
+        {
+            declaredLocals.Add(designation.Identifier.Text);
+        }
+
+        foreach (var catchDecl in root.DescendantNodes().OfType<CatchDeclarationSyntax>())
+        {
+            declaredLocals.Add(catchDecl.Identifier.Text);
+        }
+
         foreach (var identifier in root.DescendantNodes().OfType<IdentifierNameSyntax>())
         {
             var name = identifier.Identifier.Text;


### PR DESCRIPTION
## Summary
- `DetectFreeVariables` only collected `VariableDeclaratorSyntax`, missing three other Roslyn declaration forms: `ForEachStatementSyntax`, `SingleVariableDesignationSyntax` (`is` pattern variables), and `CatchDeclarationSyntax`
- These variables were incorrectly treated as free variables, becoming spurious UDF parameters (causing `#NAME?` in Excel)
- Added three unit tests covering each missed declaration form

Closes #212

## Test plan
- [x] All 37 `InputDetectorTests` pass (3 new + 34 existing)
- [x] Run AddIn tests to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)