### PR TITLE
Dot-to-bracket completion for Row types after LINQ methods

### DIFF
--- a/formula-boss.Tests/RoslynCompletionTests.cs
+++ b/formula-boss.Tests/RoslynCompletionTests.cs
@@ -190,4 +190,55 @@ public class RoslynCompletionTests : IDisposable
         Assert.Contains("input", texts);
         Assert.Contains("myFormula", texts);
     }
+
+    [Fact]
+    public async Task RowAfterFirst_ShowsColumnCompletionsAsBracket()
+    {
+        var formula = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).`)";
+        var textUp = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        var texts = items.Select(i => i.Text).ToList();
+        Assert.Contains("Date", texts);
+        Assert.Contains("Amount", texts);
+        Assert.Contains("Region", texts);
+
+        // Items should be ColumnCompletionData (bracket-inserting), not plain CompletionData
+        Assert.All(items, item => Assert.IsType<ColumnCompletionData>(item));
+    }
+
+    [Fact]
+    public async Task RowAfterFirstOrDefault_ShowsColumnCompletions()
+    {
+        var formula = "=LET(t, Sales, `t.Rows.FirstOrDefault(r => r[\"Region\"] == \"West\").`)";
+        var textUp = "=LET(t, Sales, `t.Rows.FirstOrDefault(r => r[\"Region\"] == \"West\").";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        var texts = items.Select(i => i.Text).ToList();
+        Assert.Contains("Date", texts);
+        Assert.Contains("Amount", texts);
+        Assert.Contains("Region", texts);
+        Assert.All(items, item => Assert.IsType<ColumnCompletionData>(item));
+    }
+
+    [Fact]
+    public async Task NonRowType_NotAffected()
+    {
+        // String.Length is not a Row — should still return normal Roslyn completions
+        var formula = "=`\"hello\".`";
+        var textUp = "=`\"hello\".";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        var texts = items.Select(i => i.Text).ToList();
+        Assert.Contains("Length", texts);
+
+        // These should be regular CompletionData, not ColumnCompletionData
+        Assert.All(items, item => Assert.IsNotType<ColumnCompletionData>(item));
+    }
 }

--- a/formula-boss/UI/Completion/RoslynCompletionProvider.cs
+++ b/formula-boss/UI/Completion/RoslynCompletionProvider.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.CodeAnalysis.Completion;
+﻿using System.Text.RegularExpressions;
+
+using FormulaBoss.Transpilation;
+
+using Microsoft.CodeAnalysis.Completion;
 
 namespace FormulaBoss.UI.Completion;
 
@@ -64,8 +68,64 @@ internal sealed class RoslynCompletionProvider
             return (Array.Empty<CompletionData>(), false);
         }
 
+        // Check if the expression before the dot is a Row type — if so,
+        // replace Roslyn's property completions with bracket-inserting column completions
+        var tableName = await ResolveRowTableNameAsync(caretOffset, metadata, cancellationToken);
+        if (tableName != null)
+        {
+            var columnItems = CompletionHelpers.BuildRowCompletions(metadata, false, tableName);
+            return (columnItems, false);
+        }
+
         var result = MapCompletionItems(roslynItems);
         return (result, false);
+    }
+
+    /// <summary>
+    ///     If the expression before the dot is a synthetic Row type, resolves the original
+    ///     table name. Returns null if not a Row type.
+    /// </summary>
+    private async Task<string?> ResolveRowTableNameAsync(
+        int caretOffset, WorkbookMetadata? metadata, CancellationToken cancellationToken)
+    {
+        if (metadata == null)
+        {
+            return null;
+        }
+
+        var typeName = await _workspace.GetTypeBeforeDotAsync(caretOffset, cancellationToken);
+        if (typeName == null)
+        {
+            return null;
+        }
+
+        // Strip nullable suffix
+        var coreName = typeName.EndsWith("?") ? typeName[..^1] : typeName;
+
+        var match = Regex.Match(coreName, @"^__(.+)Row$");
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        var sanitisedName = match.Groups[1].Value;
+
+        // Exclude RowCollection matches
+        if (sanitisedName.EndsWith("RowCollection"))
+        {
+            return null;
+        }
+
+        // Resolve sanitised name back to original table name
+        foreach (var (originalName, _) in metadata.TableColumns)
+        {
+            if (ColumnMapper.Sanitise(originalName) == sanitisedName)
+            {
+                return originalName;
+            }
+        }
+
+        return null;
     }
 
     private static List<CompletionData> MapCompletionItems(IReadOnlyList<CompletionItem> items)

--- a/formula-boss/UI/Completion/RoslynWorkspaceManager.cs
+++ b/formula-boss/UI/Completion/RoslynWorkspaceManager.cs
@@ -387,6 +387,53 @@ internal sealed class RoslynWorkspaceManager : IDisposable
     }
 
     /// <summary>
+    ///     Returns the display name of the type of the expression before the dot at the given
+    ///     caret offset. Must be called after <see cref="GetCompletionsAsync" /> which loads
+    ///     the document into the workspace.
+    /// </summary>
+    public async Task<string?> GetTypeBeforeDotAsync(int caretOffset, CancellationToken cancellationToken)
+    {
+        var document = _workspace.CurrentSolution.GetDocument(_documentId);
+        if (document == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            if (semanticModel == null || root == null)
+            {
+                return null;
+            }
+
+            var token = root.FindToken(Math.Max(0, caretOffset - 1));
+
+            var memberAccess = token.Parent?.AncestorsAndSelf()
+                .OfType<MemberAccessExpressionSyntax>()
+                .FirstOrDefault();
+
+            if (memberAccess == null)
+            {
+                return null;
+            }
+
+            var typeInfo = semanticModel.GetTypeInfo(memberAccess.Expression, cancellationToken);
+            return typeInfo.Type?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Type lookup error: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
     ///     Pre-warms the workspace by requesting completions on a trivial document.
     /// </summary>
     public async Task WarmUpAsync()

--- a/formula-boss/UI/CompletionProvider.cs
+++ b/formula-boss/UI/CompletionProvider.cs
@@ -132,7 +132,7 @@ internal static class CompletionHelpers
         return tableName;
     }
 
-    private static IReadOnlyList<CompletionData> BuildRowCompletions(
+    internal static IReadOnlyList<CompletionData> BuildRowCompletions(
         WorkbookMetadata? metadata, bool isBracketContext, string? tableName)
     {
         var items = new List<CompletionData>();


### PR DESCRIPTION
## Summary

- After LINQ methods that return a Row (`.First()`, `.FirstOrDefault()`), dot completions now show column names with bracket insertion
- Uses the Roslyn workspace semantic model to detect `__*Row` types at the cursor position
- Resolves synthetic type names back to original table names for column lookup
- Existing lambda parameter column completions (`r.` inside `.Where()`) are unaffected

## Implementation

- `RoslynWorkspaceManager.GetTypeBeforeDotAsync` — queries the semantic model for the type of the expression before the dot
- `RoslynCompletionProvider.ResolveRowTableNameAsync` — detects Row types and resolves table names
- `CompletionHelpers.BuildRowCompletions` — made internal for reuse (was private)

## Test plan

- [x] 3 new tests: `.First()` row completions, `.FirstOrDefault()` row completions, non-row types unaffected
- [x] All 14 Roslyn completion tests pass (11 existing + 3 new)
- [x] All 658 non-addin tests pass
- [x] Manual test in Excel with actual table data

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)