### PR TITLE
Add indexers and IndexOf to IExcelRange

### DIFF
--- a/formula-boss.Runtime.Tests/ExcelArrayTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelArrayTests.cs
@@ -538,6 +538,32 @@ public class ExcelArrayTests
         Assert.Equal("Bob", arr[idx]);
     }
 
+    [Fact]
+    public void IndexOf_RawValue_FindsString()
+    {
+        var arr = MakeArray();
+        Assert.Equal(1, arr.IndexOf("Alice"));
+        Assert.Equal(3, arr.IndexOf("Bob"));
+        Assert.Equal(-1, arr.IndexOf("Nobody"));
+    }
+
+    [Fact]
+    public void IndexOf_RawValue_FindsDouble()
+    {
+        var arr = MakeArray();
+        Assert.Equal(0, arr.IndexOf(1.0));
+        Assert.Equal(2, arr.IndexOf(2.0));
+        Assert.Equal(-1, arr.IndexOf(99.0));
+    }
+
+    [Fact]
+    public void IndexOf_RawValue_WithIndexer_Roundtrips()
+    {
+        var arr = MakeArray();
+        var idx = arr.IndexOf("Bob");
+        Assert.Equal("Bob", arr[idx]);
+    }
+
     // --- Map ---
 
     [Fact]

--- a/formula-boss.Runtime.Tests/ExcelScalarTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelScalarTests.cs
@@ -300,6 +300,20 @@ public class ExcelScalarTests
     }
 
     [Fact]
+    public void IndexOf_RawValue_MatchingReturnsZero()
+    {
+        var scalar = new ExcelScalar(42.0);
+        Assert.Equal(0, scalar.IndexOf(42.0));
+    }
+
+    [Fact]
+    public void IndexOf_RawValue_NonMatchingReturnsMinusOne()
+    {
+        var scalar = new ExcelScalar(42.0);
+        Assert.Equal(-1, scalar.IndexOf(99.0));
+    }
+
+    [Fact]
     public void ArithmeticOperators_Work()
     {
         var a = new ExcelScalar(10.0);

--- a/formula-boss.Runtime/ExcelArray.cs
+++ b/formula-boss.Runtime/ExcelArray.cs
@@ -280,6 +280,25 @@ public class ExcelArray : ExcelValue, IExcelRange
         return -1;
     }
 
+    public override int IndexOf(object? value)
+    {
+        var rows = _data.GetLength(0);
+        var cols = _data.GetLength(1);
+        var i = 0;
+        for (var r = 0; r < rows; r++)
+            for (var c = 0; c < cols; c++)
+            {
+                if (Equals(_data[r, c], value))
+                {
+                    return i;
+                }
+
+                i++;
+            }
+
+        return -1;
+    }
+
     /// <inheritdoc />
     public override IEnumerator<ExcelValue> GetEnumerator() => ElementWise().GetEnumerator();
 

--- a/formula-boss.Runtime/ExcelScalar.cs
+++ b/formula-boss.Runtime/ExcelScalar.cs
@@ -132,6 +132,8 @@ public class ExcelScalar : ExcelValue, IExcelRange
 
     public override int IndexOf(ExcelValue value) => Equals(RawValue, value.RawValue) ? 0 : -1;
 
+    public override int IndexOf(object? value) => Equals(RawValue, value) ? 0 : -1;
+
     /// <inheritdoc />
     public override IEnumerator<ExcelValue> GetEnumerator()
     {

--- a/formula-boss.Runtime/ExcelValue.cs
+++ b/formula-boss.Runtime/ExcelValue.cs
@@ -128,6 +128,9 @@ public abstract class ExcelValue : IExcelRange, IComparable<ExcelValue>, ICompar
     /// <inheritdoc />
     public abstract int IndexOf(ExcelValue value);
 
+    /// <inheritdoc />
+    public abstract int IndexOf(object? value);
+
     /// <summary>Wraps a raw Excel value into the appropriate ExcelValue subtype.</summary>
     /// <param name="value">The raw value from Excel (scalar, object[,], or existing ExcelValue).</param>
     /// <param name="headers">Column headers — if provided, creates an ExcelTable instead of ExcelArray.</param>

--- a/formula-boss.Runtime/IExcelRange.cs
+++ b/formula-boss.Runtime/IExcelRange.cs
@@ -112,4 +112,8 @@ public interface IExcelRange : IEnumerable<ExcelValue>
     /// <summary>Returns the linear (row-major) index of the first element matching the given value, or -1 if not found.</summary>
     /// <param name="value">The value to search for.</param>
     int IndexOf(ExcelValue value);
+
+    /// <summary>Returns the linear (row-major) index of the first element matching the given raw value, or -1 if not found.</summary>
+    /// <param name="value">The raw value to search for (string, double, etc.).</param>
+    int IndexOf(object? value);
 }


### PR DESCRIPTION
## Summary

- Add `this[int row, int col]` — 2D indexer for direct element access
- Add `this[int index]` — linear row-major indexer
- Add `IndexOf(ExcelValue)` — linear row-major search returning flat index (-1 if not found)

All three are defined on `IExcelRange` with abstract declarations on `ExcelValue`, and concrete implementations on `ExcelArray` and `ExcelScalar`. `ExcelTable` inherits from `ExcelArray`.

Closes #232

## Test plan

- [x] ExcelArray: 2D indexer returns correct elements
- [x] ExcelArray: 2D indexer throws on out-of-range
- [x] ExcelArray: linear indexer follows row-major order
- [x] ExcelArray: linear indexer throws on out-of-range
- [x] ExcelArray: IndexOf finds elements at correct linear position
- [x] ExcelArray: IndexOf returns -1 when not found
- [x] ExcelArray: IndexOf + linear indexer roundtrip
- [x] ExcelScalar: [0,0] and [0] return self
- [x] ExcelScalar: non-zero indices throw
- [x] ExcelScalar: IndexOf match returns 0, non-match returns -1
- [x] All 203 Runtime tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)