### PR TITLE
Move build instructions from README to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ Thanks for your interest in contributing! This guide covers what you need to get
 dotnet build formula-boss/formula-boss.slnx
 ```
 
+## Loading in Excel
+
+After building, load the add-in manually:
+
+1. Open Excel → File → Options → Add-ins → Manage: Excel Add-ins → Go
+2. Browse to `formula-boss/bin/Debug/net6.0-windows/formula-boss64.xll` (or `formula-boss.xll` for 32-bit)
+
 ## Running Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -101,21 +101,6 @@ A statement expression with a `foreach` loop, `List<double>`, and visited-step t
 
 Requires **64-bit Excel** (Microsoft 365 or Excel 2019+) on Windows 10/11. The installer bundles the .NET 6 runtime.
 
-## Building
-
-Requires [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0).
-
-```bash
-dotnet build formula-boss/formula-boss.slnx
-dotnet test formula-boss/formula-boss.slnx
-```
-
-## Loading in Excel
-
-1. Build the project
-2. Open Excel → File → Options → Add-ins → Manage: Excel Add-ins → Go
-3. Browse to `formula-boss/bin/Debug/net6.0-windows/formula-boss64.xll` (or `formula-boss.xll` for 32-bit)
-
 ## Documentation
 
 - [User Specification](specs/0005-formula-boss-user-spec.md) — full expression language, type system, and operation reference


### PR DESCRIPTION
## Summary
- Removed "Building" and "Loading in Excel" sections from README to keep it focused on end users
- Added "Loading in Excel" section to CONTRIBUTING.md alongside the existing build instructions

## Test plan
- [x] Verify README reads cleanly for end users (Download → Documentation flow)
- [x] Verify CONTRIBUTING.md has complete build + load instructions for contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)