### PR TITLE
Fix GroupBy intellisense showing Row columns instead of RowGroup members

### DIFF
--- a/formula-boss.Tests/RoslynCompletionTests.cs
+++ b/formula-boss.Tests/RoslynCompletionTests.cs
@@ -241,4 +241,63 @@ public class RoslynCompletionTests : IDisposable
         // These should be regular CompletionData, not ColumnCompletionData
         Assert.All(items, item => Assert.IsNotType<ColumnCompletionData>(item));
     }
+
+    [Fact]
+    public async Task GroupBySelect_ShowsRowGroupMembers_NotColumnNames()
+    {
+        var formula = "=LET(t, Sales, `t.Rows.GroupBy(r => r[\"Region\"]).Select(g => g.`)";
+        var textUp = "=LET(t, Sales, `t.Rows.GroupBy(r => r[\"Region\"]).Select(g => g.";
+
+        var (items, isBracket) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        Assert.False(isBracket);
+        var texts = items.Select(i => i.Text).ToList();
+
+        // Should show RowGroup members
+        Assert.Contains("Key", texts);
+        Assert.Contains("Count", texts);
+        Assert.Contains("Where", texts);
+        Assert.Contains("Select", texts);
+        Assert.Contains("ToRange", texts);
+
+        // Should NOT show column names (those belong to Row, not RowGroup)
+        Assert.DoesNotContain("Date", texts);
+        Assert.DoesNotContain("Amount", texts);
+        Assert.DoesNotContain("Region", texts);
+
+        // Should be regular CompletionData, not ColumnCompletionData
+        Assert.All(items, item => Assert.IsNotType<ColumnCompletionData>(item));
+    }
+
+    [Fact]
+    public async Task GroupByWhere_ShowsRowGroupMembers()
+    {
+        var formula = "=LET(t, Sales, `t.Rows.GroupBy(r => r[\"Region\"]).Where(g => g.`)";
+        var textUp = "=LET(t, Sales, `t.Rows.GroupBy(r => r[\"Region\"]).Where(g => g.";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        var texts = items.Select(i => i.Text).ToList();
+        Assert.Contains("Key", texts);
+        Assert.Contains("Count", texts);
+        Assert.DoesNotContain("Date", texts);
+    }
+
+    [Fact]
+    public async Task GroupByLambdaParam_InGroupBy_StillShowsColumns()
+    {
+        // The lambda parameter inside GroupBy itself is a Row — should show column completions
+        var formula = "=LET(t, Sales, `t.Rows.GroupBy(r => r.`)";
+        var textUp = "=LET(t, Sales, `t.Rows.GroupBy(r => r.";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        var texts = items.Select(i => i.Text).ToList();
+        Assert.Contains("Date", texts);
+        Assert.Contains("Amount", texts);
+        Assert.Contains("Region", texts);
+    }
 }

--- a/formula-boss/Analysis/TypedDocumentBuilder.cs
+++ b/formula-boss/Analysis/TypedDocumentBuilder.cs
@@ -54,11 +54,15 @@ internal static class TypedDocumentBuilder
 
             var rowTypeName = $"__{safeTableName}Row";
             var rowCollTypeName = $"__{safeTableName}RowCollection";
+            var rowGroupTypeName = $"__{safeTableName}RowGroup";
+            var groupedCollTypeName = $"__{safeTableName}GroupedRowCollection";
             var tableTypeName = $"__{safeTableName}Table";
             tableTypeNames[tableName] = tableTypeName;
 
             EmitTypedRow(sb, rowTypeName, columns);
-            EmitTypedRowCollection(sb, rowCollTypeName, rowTypeName);
+            EmitTypedRowCollection(sb, rowCollTypeName, rowTypeName, groupedCollTypeName);
+            EmitTypedRowGroup(sb, rowGroupTypeName, rowTypeName, rowCollTypeName);
+            EmitTypedGroupedRowCollection(sb, groupedCollTypeName, rowGroupTypeName);
             EmitTypedTable(sb, tableTypeName, rowCollTypeName);
         }
 
@@ -85,7 +89,7 @@ internal static class TypedDocumentBuilder
     }
 
     private static void EmitTypedRowCollection(
-        StringBuilder sb, string rowCollTypeName, string rowTypeName)
+        StringBuilder sb, string rowCollTypeName, string rowTypeName, string groupedCollTypeName)
     {
         sb.AppendLine($"class {rowCollTypeName} : IEnumerable<{rowTypeName}> {{");
         sb.AppendLine($"public {rowCollTypeName} Where(Func<{rowTypeName}, bool> predicate) => this;");
@@ -103,8 +107,51 @@ internal static class TypedDocumentBuilder
         sb.AppendLine($"public IExcelRange ToRange() => default!;");
         sb.AppendLine($"public dynamic Aggregate(dynamic seed, Func<dynamic, {rowTypeName}, dynamic> func) => default!;");
         sb.AppendLine($"public IExcelRange Scan(dynamic seed, Func<dynamic, {rowTypeName}, dynamic> func) => default!;");
-        sb.AppendLine($"public GroupedRowCollection GroupBy(Func<{rowTypeName}, object> keySelector) => default!;");
+        sb.AppendLine($"public {groupedCollTypeName} GroupBy(Func<{rowTypeName}, object> keySelector) => default!;");
         sb.AppendLine($"public IEnumerator<{rowTypeName}> GetEnumerator() => default!;");
+        sb.AppendLine($"IEnumerator IEnumerable.GetEnumerator() => default!;");
+        sb.AppendLine("}");
+        sb.AppendLine();
+    }
+
+    private static void EmitTypedRowGroup(
+        StringBuilder sb, string rowGroupTypeName, string rowTypeName, string rowCollTypeName)
+    {
+        sb.AppendLine($"class {rowGroupTypeName} : IEnumerable<{rowTypeName}> {{");
+        sb.AppendLine($"public object? Key => default;");
+        sb.AppendLine($"public {rowCollTypeName} Where(Func<{rowTypeName}, bool> predicate) => default!;");
+        sb.AppendLine($"public IExcelRange Select(Func<{rowTypeName}, object> selector) => default!;");
+        sb.AppendLine($"public bool Any(Func<{rowTypeName}, bool> predicate) => default;");
+        sb.AppendLine($"public bool All(Func<{rowTypeName}, bool> predicate) => default;");
+        sb.AppendLine($"public {rowTypeName} First(Func<{rowTypeName}, bool> predicate) => default!;");
+        sb.AppendLine($"public {rowTypeName}? FirstOrDefault(Func<{rowTypeName}, bool> predicate) => default;");
+        sb.AppendLine($"public {rowCollTypeName} OrderBy(Func<{rowTypeName}, object> keySelector) => default!;");
+        sb.AppendLine($"public {rowCollTypeName} OrderByDescending(Func<{rowTypeName}, object> keySelector) => default!;");
+        sb.AppendLine($"public int Count() => 0;");
+        sb.AppendLine($"public {rowCollTypeName} Take(int count) => default!;");
+        sb.AppendLine($"public {rowCollTypeName} Skip(int count) => default!;");
+        sb.AppendLine($"public {rowCollTypeName} Distinct() => default!;");
+        sb.AppendLine($"public IExcelRange ToRange() => default!;");
+        sb.AppendLine($"public dynamic Aggregate(dynamic seed, Func<dynamic, {rowTypeName}, dynamic> func) => default!;");
+        sb.AppendLine($"public IExcelRange Scan(dynamic seed, Func<dynamic, {rowTypeName}, dynamic> func) => default!;");
+        sb.AppendLine($"public IEnumerator<{rowTypeName}> GetEnumerator() => default!;");
+        sb.AppendLine($"IEnumerator IEnumerable.GetEnumerator() => default!;");
+        sb.AppendLine("}");
+        sb.AppendLine();
+    }
+
+    private static void EmitTypedGroupedRowCollection(
+        StringBuilder sb, string groupedCollTypeName, string rowGroupTypeName)
+    {
+        sb.AppendLine($"class {groupedCollTypeName} : IEnumerable<{rowGroupTypeName}> {{");
+        sb.AppendLine($"public IExcelRange Select(Func<{rowGroupTypeName}, object> selector) => default!;");
+        sb.AppendLine($"public {groupedCollTypeName} Where(Func<{rowGroupTypeName}, bool> predicate) => default!;");
+        sb.AppendLine($"public {groupedCollTypeName} OrderBy(Func<{rowGroupTypeName}, object> keySelector) => default!;");
+        sb.AppendLine($"public {groupedCollTypeName} OrderByDescending(Func<{rowGroupTypeName}, object> keySelector) => default!;");
+        sb.AppendLine($"public int Count() => 0;");
+        sb.AppendLine($"public {rowGroupTypeName} First() => default!;");
+        sb.AppendLine($"public {rowGroupTypeName} First(Func<{rowGroupTypeName}, bool> predicate) => default!;");
+        sb.AppendLine($"public IEnumerator<{rowGroupTypeName}> GetEnumerator() => default!;");
         sb.AppendLine($"IEnumerator IEnumerable.GetEnumerator() => default!;");
         sb.AppendLine("}");
         sb.AppendLine();

--- a/formula-boss/UI/CompletionContext.cs
+++ b/formula-boss/UI/CompletionContext.cs
@@ -365,6 +365,13 @@ public static class ContextResolver
                         return (true, FindChainRootTable(tokens, pos));
                     }
 
+                    // GroupBy transforms RowCollection → GroupedRowCollection;
+                    // lambda parameters after GroupBy are RowGroups, not Rows.
+                    if (tokens[pos].Lexeme.Equals("GroupBy", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return (false, null);
+                    }
+
                     pos--;
                 }
                 else
@@ -377,6 +384,13 @@ public static class ContextResolver
                 if (tokens[pos].Lexeme.Equals("Rows", StringComparison.OrdinalIgnoreCase))
                 {
                     return (true, FindChainRootTable(tokens, pos));
+                }
+
+                // GroupBy transforms RowCollection → GroupedRowCollection;
+                // lambda parameters after GroupBy are RowGroups, not Rows.
+                if (tokens[pos].Lexeme.Equals("GroupBy", StringComparison.OrdinalIgnoreCase))
+                {
+                    return (false, null);
                 }
 
                 pos--;


### PR DESCRIPTION
## Summary
- **ContextResolver**: `FindRowsInChain` now stops at `GroupBy` — it no longer walks past it to find `.Rows` and falsely classify group lambda params as Row context
- **TypedDocumentBuilder**: Emits synthetic `__XRowGroup` and `__XGroupedRowCollection` classes per table, so Roslyn resolves `Key`, `Count()`, `Where()`, `Select()`, `ToRange()` etc. on group lambda parameters
- **Tests**: 3 new completion tests — GroupBy+Select shows RowGroup members, GroupBy+Where shows RowGroup members, GroupBy's own lambda still shows Row columns

Closes #239

## Test plan
- [x] All 679 existing tests pass (unit + integration)
- [x] New test: `GroupBySelect_ShowsRowGroupMembers_NotColumnNames` — verifies Key/Count/Where appear, column names don't
- [x] New test: `GroupByWhere_ShowsRowGroupMembers` — same for Where context
- [x] New test: `GroupByLambdaParam_InGroupBy_StillShowsColumns` — confirms GroupBy's own lambda param still gets column completions
- [x] Manual: type `t.Rows.GroupBy(r => r["X"]).Select(g => g.` in editor, verify RowGroup members appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)