### PR TITLE
Promote RowCount/ColCount to ExcelValue base class

### DIFF
--- a/formula-boss.AddinTests/PipelineTests.cs
+++ b/formula-boss.AddinTests/PipelineTests.cs
@@ -1295,6 +1295,32 @@ public class PipelineTests
     }
 
     [Fact]
+    public void ValuePath_RowCount_OnArrayParam()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            TestUtilities.SetCellValue(ws, "A1", 10.0);
+            TestUtilities.SetCellValue(ws, "A2", 20.0);
+            TestUtilities.SetCellValue(ws, "A3", 30.0);
+
+            TestUtilities.EnterBacktickFormula(ws, "B1", "=`A1:A3.RowCount`");
+
+            var result = TestUtilities.WaitForResult(ws, "B1", _output);
+
+            _output.WriteLine($"B1 formula: {TestUtilities.GetCellFormula(ws, "B1")}");
+            _output.WriteLine($"B1 value: {result}");
+
+            Assert.NotNull(result);
+            Assert.Equal(3.0, Convert.ToDouble(result));
+        }
+        finally
+        {
+            TestUtilities.CleanupWorksheet(ws);
+        }
+    }
+
+    [Fact]
     public void Table_ColumnAccess_Sum()
     {
         var ws = _excel.AddWorksheet();

--- a/formula-boss.Runtime.Tests/ExcelArrayTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelArrayTests.cs
@@ -10,6 +10,30 @@ public class ExcelArrayTests
     private static ExcelArray MakeSingleColumn() =>
         new(new object?[,] { { 1.0 }, { 2.0 }, { 3.0 } });
 
+    // --- RowCount / ColCount ---
+
+    [Fact]
+    public void RowCount_ReturnsNumberOfRows()
+    {
+        var arr = MakeArray();
+        Assert.Equal(3, arr.RowCount);
+    }
+
+    [Fact]
+    public void ColCount_ReturnsNumberOfColumns()
+    {
+        var arr = MakeArray();
+        Assert.Equal(2, arr.ColCount);
+    }
+
+    [Fact]
+    public void RowCount_ColCount_AccessibleViaBaseType()
+    {
+        ExcelValue value = MakeArray();
+        Assert.Equal(3, value.RowCount);
+        Assert.Equal(2, value.ColCount);
+    }
+
     // --- Rows (RowCollection) ---
 
     [Fact]

--- a/formula-boss.Runtime.Tests/ExcelScalarTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelScalarTests.cs
@@ -313,6 +313,22 @@ public class ExcelScalarTests
         Assert.Equal(-1, scalar.IndexOf(99.0));
     }
 
+    // --- RowCount / ColCount ---
+
+    [Fact]
+    public void RowCount_ReturnsOne()
+    {
+        var scalar = new ExcelScalar(42.0);
+        Assert.Equal(1, scalar.RowCount);
+    }
+
+    [Fact]
+    public void ColCount_ReturnsOne()
+    {
+        var scalar = new ExcelScalar("hello");
+        Assert.Equal(1, scalar.ColCount);
+    }
+
     [Fact]
     public void ArithmeticOperators_Work()
     {

--- a/formula-boss.Runtime/ExcelArray.cs
+++ b/formula-boss.Runtime/ExcelArray.cs
@@ -23,10 +23,10 @@ public class ExcelArray : ExcelValue, IExcelRange
     public override object RawValue => _data;
 
     /// <summary>Gets the number of rows in this array.</summary>
-    public int RowCount => _data.GetLength(0);
+    public override int RowCount => _data.GetLength(0);
 
     /// <summary>Gets the number of columns in this array.</summary>
-    public int ColCount => _data.GetLength(1);
+    public override int ColCount => _data.GetLength(1);
 
     public override RowCollection Rows
     {

--- a/formula-boss.Runtime/ExcelScalar.cs
+++ b/formula-boss.Runtime/ExcelScalar.cs
@@ -13,6 +13,8 @@ public class ExcelScalar : ExcelValue, IExcelRange
     }
 
     public override object? RawValue => _value;
+    public override int RowCount => 1;
+    public override int ColCount => 1;
 
     private Row SingleRow
     {

--- a/formula-boss.Runtime/ExcelValue.cs
+++ b/formula-boss.Runtime/ExcelValue.cs
@@ -8,6 +8,12 @@ public abstract class ExcelValue : IExcelRange, IComparable<ExcelValue>, ICompar
     /// <summary>Gets the underlying raw value (a single object for scalars, object[,] for arrays).</summary>
     public abstract object? RawValue { get; }
 
+    /// <summary>Gets the number of rows in this value (1 for scalars).</summary>
+    public abstract int RowCount { get; }
+
+    /// <summary>Gets the number of columns in this value (1 for scalars).</summary>
+    public abstract int ColCount { get; }
+
     /// <inheritdoc />
     public int CompareTo(object? obj) => obj is ExcelValue ev ? CompareTo(ev) : 1;
 

--- a/formula-boss.Runtime/IExcelRange.cs
+++ b/formula-boss.Runtime/IExcelRange.cs
@@ -3,6 +3,12 @@
 /// <summary>Represents a range of Excel values supporting element-wise operations and aggregations.</summary>
 public interface IExcelRange : IEnumerable<ExcelValue>
 {
+    /// <summary>Gets the number of rows in this range (1 for scalars).</summary>
+    int RowCount { get; }
+
+    /// <summary>Gets the number of columns in this range (1 for scalars).</summary>
+    int ColCount { get; }
+
     /// <summary>Gets the rows of this range as a <see cref="RowCollection" />.</summary>
     RowCollection Rows { get; }
 

--- a/formula-boss/Analysis/TypedDocumentBuilder.cs
+++ b/formula-boss/Analysis/TypedDocumentBuilder.cs
@@ -102,6 +102,8 @@ internal static class TypedDocumentBuilder
         // Indexer for bracket access
         sb.AppendLine("public ColumnValue this[string columnName] => default!;");
         sb.AppendLine("public ColumnValue this[int index] => default!;");
+        sb.AppendLine("public int RowCount => 0;");
+        sb.AppendLine("public int ColCount => 0;");
         sb.AppendLine("public int ColumnCount => 0;");
 
         var mapping = ColumnMapper.BuildMapping(columns.ToArray());


### PR DESCRIPTION
Closes #250

## Summary
- Added abstract `RowCount` and `ColCount` properties to `ExcelValue` base class
- `ExcelScalar` returns `(1, 1)`; `ExcelArray` overrides with actual `_data` dimensions
- Added `RowCount`/`ColCount` to `IExcelRange` interface
- Updated intellisense synthetic Row stub to include `RowCount`/`ColCount`
- Added unit tests for ExcelScalar and ExcelArray, plus polymorphic access via base type
- Added AddIn test: `A1:A3.RowCount` returns 3

## Test plan
- [x] Unit tests: ExcelScalar.RowCount/ColCount return 1
- [x] Unit tests: ExcelArray.RowCount/ColCount return correct dimensions
- [x] Unit test: RowCount/ColCount accessible via ExcelValue base type reference
- [x] AddIn test: `=\`A1:A3.RowCount\`` returns 3
- [x] All existing tests pass (728 unit/integration + 40 AddIn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)