### PR TITLE
Add indexed ForEach overload for 2D iteration

### DIFF
--- a/formula-boss.Runtime.Tests/ExcelArrayTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelArrayTests.cs
@@ -325,6 +325,22 @@ public class ExcelArrayTests
         Assert.Equal(6.0, sum);
     }
 
+    [Fact]
+    public void ForEach_Indexed_ProvidesCorrectRowAndColIndices()
+    {
+        var arr = new ExcelArray(new object?[,] { { 1.0, 2.0 }, { 3.0, 4.0 }, { 5.0, 6.0 } });
+        var visited = new List<(double val, int row, int col)>();
+        arr.ForEach((val, row, col) => visited.Add(((double)val, row, col)));
+
+        Assert.Equal(6, visited.Count);
+        Assert.Equal((1.0, 0, 0), visited[0]);
+        Assert.Equal((2.0, 0, 1), visited[1]);
+        Assert.Equal((3.0, 1, 0), visited[2]);
+        Assert.Equal((4.0, 1, 1), visited[3]);
+        Assert.Equal((5.0, 2, 0), visited[4]);
+        Assert.Equal((6.0, 2, 1), visited[5]);
+    }
+
     // --- SelectMany ---
 
     [Fact]

--- a/formula-boss.Runtime.Tests/ExcelScalarTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelScalarTests.cs
@@ -343,4 +343,15 @@ public class ExcelScalarTests
         Assert.Equal(15.0, (double)(c * 3));
         Assert.Equal(7.0, (double)(c + 2));
     }
+
+    [Fact]
+    public void ForEach_Indexed_CallsWithZeroZero()
+    {
+        var scalar = new ExcelScalar(42.0);
+        var visited = new List<(double val, int row, int col)>();
+        scalar.ForEach((val, row, col) => visited.Add(((double)val, row, col)));
+
+        Assert.Single(visited);
+        Assert.Equal((42.0, 0, 0), visited[0]);
+    }
 }

--- a/formula-boss.Runtime/ExcelArray.cs
+++ b/formula-boss.Runtime/ExcelArray.cs
@@ -346,6 +346,18 @@ public class ExcelArray : ExcelValue, IExcelRange
     /// <inheritdoc />
     public override IEnumerator<ExcelValue> GetEnumerator() => ElementWise().GetEnumerator();
 
+    /// <inheritdoc />
+    public override void ForEach(Action<ExcelValue, int, int> action)
+    {
+        var rows = _data.GetLength(0);
+        var cols = _data.GetLength(1);
+        for (var r = 0; r < rows; r++)
+            for (var c = 0; c < cols; c++)
+            {
+                action(new ExcelScalar(_data[r, c]), r, c);
+            }
+    }
+
     // --- Element-wise operations (iterate cell-by-cell, row-major) ---
 
     private IEnumerable<ExcelScalar> ElementWise()

--- a/formula-boss.Runtime/ExcelScalar.cs
+++ b/formula-boss.Runtime/ExcelScalar.cs
@@ -170,6 +170,9 @@ public class ExcelScalar : ExcelValue, IExcelRange
     public override int IndexOf(object? value) => Equals(RawValue, value) ? 0 : -1;
 
     /// <inheritdoc />
+    public override void ForEach(Action<ExcelValue, int, int> action) => action(this, 0, 0);
+
+    /// <inheritdoc />
     public override IEnumerator<ExcelValue> GetEnumerator()
     {
         yield return this;

--- a/formula-boss.Runtime/ExcelValue.cs
+++ b/formula-boss.Runtime/ExcelValue.cs
@@ -123,6 +123,9 @@ public abstract class ExcelValue : IExcelRange, IComparable<ExcelValue>, ICompar
     }
 
     /// <inheritdoc />
+    public abstract void ForEach(Action<ExcelValue, int, int> action);
+
+    /// <inheritdoc />
     public abstract dynamic Aggregate(dynamic seed, Func<dynamic, dynamic, dynamic> func);
 
     /// <inheritdoc />

--- a/formula-boss.Runtime/IExcelRange.cs
+++ b/formula-boss.Runtime/IExcelRange.cs
@@ -96,6 +96,10 @@ public interface IExcelRange : IEnumerable<ExcelValue>
     /// <param name="action">The action to perform on each element.</param>
     void ForEach(Action<ExcelValue> action);
 
+    /// <summary>Executes an action for each element with its row and column indices.</summary>
+    /// <param name="action">The action to perform on each element, receiving (value, row, col).</param>
+    void ForEach(Action<ExcelValue, int, int> action);
+
     /// <summary>Applies an accumulator function over the elements, returning the final result.</summary>
     /// <param name="seed">The initial accumulator value.</param>
     /// <param name="func">A function that takes (accumulator, element) and returns the new accumulator.</param>


### PR DESCRIPTION
## Summary
- Add `ForEach(Action<ExcelValue, int, int>)` overload to `IExcelRange`, `ExcelValue` (abstract), `ExcelArray`, and `ExcelScalar`
- ExcelArray iterates row-major providing (value, row, col); ExcelScalar calls with (value, 0, 0)
- Unit tests for both array and scalar cases

Closes #254

## Test plan
- [x] Unit test: ExcelArray ForEach_Indexed verifies correct indices for 3x2 array
- [x] Unit test: ExcelScalar ForEach_Indexed verifies (0, 0) indices
- [x] Intellisense: method appears via Roslyn workspace (uses actual Runtime assembly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)