### PR TITLE
Fix settings dialog changes overwritten by stale editor copy

### DIFF
--- a/formula-boss/Commands/ShowFloatingEditorCommand.cs
+++ b/formula-boss/Commands/ShowFloatingEditorCommand.cs
@@ -401,8 +401,7 @@ public static class ShowFloatingEditorCommand
 
                     if (_window is { IsVisible: true })
                     {
-                        _window.ApplyIndentSize(settings.IndentSize);
-                        _window.ApplyWordWrap(settings.WordWrap);
+                        _window.ApplySettings(settings);
                     }
                 }
             });

--- a/formula-boss/UI/EditorSettings.cs
+++ b/formula-boss/UI/EditorSettings.cs
@@ -52,6 +52,19 @@ public class EditorSettings
         return new EditorSettings();
     }
 
+    public void CopyFrom(EditorSettings other)
+    {
+        Width = other.Width;
+        Height = other.Height;
+        IndentSize = other.IndentSize;
+        FontSize = other.FontSize;
+        AnimationStyle = other.AnimationStyle;
+        WordWrap = other.WordWrap;
+        AutoFormatLet = other.AutoFormatLet;
+        NestedLetDepth = other.NestedLetDepth;
+        MaxLineLength = other.MaxLineLength;
+    }
+
     public void Save()
     {
         try

--- a/formula-boss/UI/FloatingEditorWindow.xaml.cs
+++ b/formula-boss/UI/FloatingEditorWindow.xaml.cs
@@ -403,14 +403,11 @@ public partial class FloatingEditorWindow
         Hide();
     }
 
-    internal void ApplyWordWrap(bool wordWrap)
+    internal void ApplySettings(EditorSettings settings)
     {
-        FormulaEditor.WordWrap = wordWrap;
-    }
-
-    internal void ApplyIndentSize(int indentSize)
-    {
-        FormulaEditor.Options.IndentationSize = indentSize;
+        _settings.CopyFrom(settings);
+        FormulaEditor.WordWrap = settings.WordWrap;
+        FormulaEditor.Options.IndentationSize = settings.IndentSize;
     }
 
     internal void DisposeWorkspace()


### PR DESCRIPTION
## Summary
- Added `EditorSettings.CopyFrom()` to sync all properties from one settings instance to another
- Replaced separate `ApplyWordWrap`/`ApplyIndentSize` calls with a single `ApplySettings()` method on `FloatingEditorWindow` that copies the full settings object, keeping the editor's internal `_settings` in sync with what the dialog saved
- Prevents resize/font/word-wrap saves from overwriting dialog changes with stale values

Closes #268

## Test plan
- [x] All 805 tests pass (278 Runtime, 452 unit, 34 integration, 41 AddIn)
- [x] Manual repro: open editor → open settings → change value → OK → resize editor → reopen settings → verify change persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)