### PR TITLE
Add LetFormulaFormatter with configurable formatting (#265)

### DIFF
--- a/formula-boss.Tests/LetFormulaFormatterTests.cs
+++ b/formula-boss.Tests/LetFormulaFormatterTests.cs
@@ -1,0 +1,380 @@
+using FormulaBoss.Interception;
+
+using Xunit;
+
+namespace FormulaBoss.Tests;
+
+public class LetFormulaFormatterTests
+{
+    #region Basic Formatting
+
+    [Fact]
+    public void Format_BasicLet_IndentsBindings()
+    {
+        var formula = "=LET(x, A1, y, B1, x + y)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        var expected = "=LET(\n    x, A1,\n    y, B1,\n    x + y)";
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Format_BasicLet_DefaultIndentSize()
+    {
+        var formula = "=LET(x, A1, y, B1, x + y)";
+
+        var result = LetFormulaFormatter.Format(formula);
+
+        var expected = "=LET(\n  x, A1,\n  y, B1,\n  x + y)";
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Format_SingleBinding()
+    {
+        var formula = "=LET(x, 1, x)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        var expected = "=LET(\n    x, 1,\n    x)";
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Format_AlreadyFormatted_ReformatsCleanly()
+    {
+        var formula = "=LET(\n    x, A1,\n    y, B1,\n    x + y)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.Equal(formula, result);
+    }
+
+    [Fact]
+    public void Format_ClosingParenOnResultLine()
+    {
+        var formula = "=LET(x, 1, y, 2, x + y)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 2);
+
+        // Style A: closing paren on same line as result
+        Assert.EndsWith("x + y)", result);
+    }
+
+    [Fact]
+    public void Format_NameAndValueOnSameLine()
+    {
+        var formula = "=LET(x, SUM(A1:A10), y, AVERAGE(B1:B5), x + y)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.Contains("x, SUM(A1:A10),", result);
+        Assert.Contains("y, AVERAGE(B1:B5),", result);
+    }
+
+    #endregion
+
+    #region Nested LETs
+
+    [Fact]
+    public void Format_NestedLet_Depth1_LeavesNestedAsIs()
+    {
+        var formula = "=LET(x, A1, result, LET(y, B1, z, C1, y + z), x + result)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4, nestedLetDepth: 1);
+
+        // Top-level is formatted, nested LET is left as-is
+        Assert.Contains("result, LET(y, B1, z, C1, y + z),", result);
+    }
+
+    [Fact]
+    public void Format_NestedLet_Depth2_FormatsOneLevel()
+    {
+        var formula = "=LET(x, A1, result, LET(y, B1, z, C1, y + z), x + result)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4, nestedLetDepth: 2);
+
+        // Nested LET should be formatted with additional indentation
+        Assert.Contains("result, LET(", result);
+        Assert.Contains("        y, B1,", result); // 8 spaces = 4 + 4
+        Assert.Contains("        z, C1,", result);
+        Assert.Contains("        y + z)", result);
+    }
+
+    [Fact]
+    public void Format_NestedLet_Depth3_FormatsTwoLevels()
+    {
+        var formula = "=LET(a, 1, b, LET(c, 2, d, LET(e, 3, e + 1), c + d), a + b)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 2, nestedLetDepth: 3);
+
+        // All three levels formatted
+        Assert.Contains("  b, LET(", result);     // 2 spaces
+        Assert.Contains("    c, 2,", result);       // 4 spaces
+        Assert.Contains("    d, LET(", result);     // 4 spaces
+        Assert.Contains("      e, 3,", result);     // 6 spaces
+    }
+
+    [Fact]
+    public void Format_NestedLetDepth0_NoFormatting()
+    {
+        var formula = "=LET(x, 1, y, 2, x + y)";
+
+        var result = LetFormulaFormatter.Format(formula, nestedLetDepth: 0);
+
+        Assert.Equal(formula, result);
+    }
+
+    #endregion
+
+    #region MaxLineLength Inlining
+
+    [Fact]
+    public void Format_MaxLineLength_InlinesShortBindings()
+    {
+        var formula = "=LET(x, A1, y, B1, total, SUM(x, y), total)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4, maxLineLength: 40);
+
+        // Short bindings should be inlined on the =LET( line
+        Assert.StartsWith("=LET(x, A1, y, B1,", result);
+    }
+
+    [Fact]
+    public void Format_MaxLineLength_WrapsWhenExceeded()
+    {
+        var formula = "=LET(x, A1, y, B1, total, SUM(x, y), total)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4, maxLineLength: 25);
+
+        // First binding fits, subsequent ones wrap
+        Assert.Contains("=LET(x, A1,", result);
+        Assert.Contains("\n", result);
+    }
+
+    [Fact]
+    public void Format_MaxLineLength_Zero_AlwaysWraps()
+    {
+        var formula = "=LET(x, 1, x)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4, maxLineLength: 0);
+
+        // Even short formulas should wrap
+        Assert.Contains("\n", result);
+    }
+
+    [Fact]
+    public void Format_MaxLineLength_AllFitOnOneLine()
+    {
+        var formula = "=LET(x, 1, y, 2, x + y)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4, maxLineLength: 100);
+
+        // Everything fits on one line, result on same line
+        Assert.Equal("=LET(x, 1, y, 2, x + y)", result);
+    }
+
+    [Fact]
+    public void Format_MaxLineLength_OnceWrapped_AllSubsequentWrap()
+    {
+        var formula = "=LET(a, 1, b, 2, c, 3, d, 4, a + b + c + d)";
+
+        // Set limit such that first two fit but third doesn't
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4, maxLineLength: 22);
+
+        // Once wrapping starts, all subsequent bindings wrap
+        var lines = result.Split('\n');
+        Assert.True(lines.Length >= 3, "Expected wrapping after limit exceeded");
+    }
+
+    #endregion
+
+    #region String Literals
+
+    [Fact]
+    public void Format_StringLiteralWithCommas_NotSplit()
+    {
+        var formula = "=LET(msg, \"hello, world\", x, 1, msg)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.Contains("msg, \"hello, world\",", result);
+    }
+
+    [Fact]
+    public void Format_StringLiteralWithParens_NotSplit()
+    {
+        var formula = "=LET(msg, \"value (test)\", msg)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.Contains("msg, \"value (test)\",", result);
+    }
+
+    #endregion
+
+    #region Array Constants
+
+    [Fact]
+    public void Format_ArrayConstant_KeptOnOneLine()
+    {
+        var formula = "=LET(arr, {1,2,3;4,5,6}, SUM(arr))";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.Contains("arr, {1,2,3;4,5,6},", result);
+    }
+
+    #endregion
+
+    #region Backtick Expressions
+
+    [Fact]
+    public void Format_BacktickExpression_PreservedExactly()
+    {
+        var formula = "=LET(data, A1:A10, filtered, `data.where(v => v > 0)`, SUM(filtered))";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.Contains("filtered, `data.where(v => v > 0)`,", result);
+    }
+
+    [Fact]
+    public void Format_BacktickWithCommas_PreservedExactly()
+    {
+        var formula = "=LET(out, `new int[] { 1, 2, 3 }`, SUM(out))";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.Contains("out, `new int[] { 1, 2, 3 }`,", result);
+    }
+
+    #endregion
+
+    #region LET Inside Other Functions
+
+    [Fact]
+    public void Format_LetInsideSumproduct()
+    {
+        var formula = "=SUMPRODUCT(LET(x, A1:A10, x * 2))";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.StartsWith("=SUMPRODUCT(LET(", result);
+        Assert.Contains("    x, A1:A10,", result);
+        Assert.Contains("    x * 2)", result);
+        Assert.EndsWith(")", result);
+    }
+
+    [Fact]
+    public void Format_LetInsideIf()
+    {
+        var formula = "=IF(A1>0, LET(x, A1, y, B1, x + y), 0)";
+
+        // Fallback: formula doesn't start with =LET( and LET is not directly inside outer func
+        // This should attempt wrapped LET formatting
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        // For now this is a complex case — the formatter should handle it or return unchanged
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void Format_NonLetFormula_ReturnedUnchanged()
+    {
+        var formula = "=SUM(A1:A10)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.Equal(formula, result);
+    }
+
+    #endregion
+
+    #region AutoFormatLet Bypass
+
+    [Fact]
+    public void Format_NestedLetDepthZero_ReturnsOriginal()
+    {
+        // AutoFormatLet = false is handled by caller, but NestedLetDepth = 0 disables formatting
+        var formula = "=LET(x, 1, y, 2, x + y)";
+
+        var result = LetFormulaFormatter.Format(formula, nestedLetDepth: 0);
+
+        Assert.Equal(formula, result);
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public void Format_NullFormula_ReturnsNull()
+    {
+        var result = LetFormulaFormatter.Format(null!, indentSize: 4);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Format_EmptyFormula_ReturnsEmpty()
+    {
+        var result = LetFormulaFormatter.Format("", indentSize: 4);
+
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void Format_WhitespaceOnly_ReturnsUnchanged()
+    {
+        var result = LetFormulaFormatter.Format("   ", indentSize: 4);
+
+        Assert.Equal("   ", result);
+    }
+
+    [Fact]
+    public void Format_MalformedLet_ReturnsUnchanged()
+    {
+        var formula = "=LET(x, 1";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        Assert.Equal(formula, result);
+    }
+
+    [Fact]
+    public void Format_CaseInsensitiveLet()
+    {
+        var formula = "=let(x, 1, y, 2, x + y)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        // Should still format (parser is case-insensitive)
+        Assert.Contains("\n", result);
+    }
+
+    [Fact]
+    public void Format_NonLetFunctionCallsInValues_NotReformatted()
+    {
+        var formula = "=LET(x, FILTER(SORT(A1:A100, 2, -1), B1:B100 > 0), SUM(x))";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 4);
+
+        // The complex function call should be preserved as-is
+        Assert.Contains("x, FILTER(SORT(A1:A100, 2, -1), B1:B100 > 0),", result);
+    }
+
+    [Fact]
+    public void Format_ManyBindings()
+    {
+        var formula = "=LET(a, 1, b, 2, c, 3, d, 4, e, 5, a + b + c + d + e)";
+
+        var result = LetFormulaFormatter.Format(formula, indentSize: 2);
+
+        var lines = result.Split('\n');
+        Assert.Equal(7, lines.Length); // =LET( + 5 bindings + result
+    }
+
+    #endregion
+}

--- a/formula-boss/Interception/FormulaInterceptor.cs
+++ b/formula-boss/Interception/FormulaInterceptor.cs
@@ -318,8 +318,9 @@ public class FormulaInterceptor : IDisposable
             return;
         }
 
+        var settings = EditorSettings.Load();
         var newFormula = LetFormulaRewriter.Rewrite(letStructure, processedBindings, processedResults,
-            rewrittenResultExpression);
+            rewrittenResultExpression, settings.IndentSize);
         Debug.WriteLine($"Rewriting LET formula to: {newFormula}");
 
         WriteFormula(cell, newFormula);

--- a/formula-boss/Interception/LetFormulaFormatter.cs
+++ b/formula-boss/Interception/LetFormulaFormatter.cs
@@ -1,0 +1,247 @@
+using System.Text;
+
+namespace FormulaBoss.Interception;
+
+/// <summary>
+///     Formats LET formulas with configurable indentation, nesting depth, and line length.
+///     Preserves non-LET function calls, string literals, array constants, and backtick expressions.
+/// </summary>
+public static class LetFormulaFormatter
+{
+    private const char NewLine = '\n'; // Use LF only - Excel COM doesn't like \r\n
+
+    /// <summary>
+    ///     Formats a LET formula according to the specified settings.
+    ///     Returns the original formula unchanged if it cannot be parsed or formatting is disabled.
+    /// </summary>
+    /// <param name="formula">The formula to format.</param>
+    /// <param name="indentSize">Number of spaces per indent level.</param>
+    /// <param name="nestedLetDepth">How many levels of nested LETs to format (0 = off, 1 = top only).</param>
+    /// <param name="maxLineLength">Max line length before wrapping (0 = always wrap).</param>
+    /// <returns>The formatted formula.</returns>
+    public static string Format(string formula, int indentSize = 2, int nestedLetDepth = 1, int maxLineLength = 0)
+    {
+        if (string.IsNullOrWhiteSpace(formula) || nestedLetDepth <= 0)
+        {
+            return formula;
+        }
+
+        // Check if the formula starts with = followed by optional wrapping function then LET(
+        var trimmed = formula.TrimStart();
+        if (!trimmed.StartsWith("=", StringComparison.Ordinal))
+        {
+            return formula;
+        }
+
+        // Find the LET( in the formula
+        var afterEquals = trimmed.Substring(1).TrimStart();
+        if (afterEquals.StartsWith("LET(", StringComparison.OrdinalIgnoreCase))
+        {
+            // Direct =LET(...) formula
+            return FormatDirectLet(trimmed, indentSize, nestedLetDepth, maxLineLength);
+        }
+
+        // Check for LET inside another function: =FUNC(LET(...))
+        return FormatWrappedLet(trimmed, indentSize, nestedLetDepth, maxLineLength);
+    }
+
+    private static string FormatDirectLet(string formula, int indentSize, int nestedLetDepth, int maxLineLength)
+    {
+        if (!LetFormulaParser.TryParse(formula, out var structure) || structure == null)
+        {
+            return formula;
+        }
+
+        var sb = new StringBuilder();
+        sb.Append("=LET(");
+        var indent = new string(' ', indentSize);
+        FormatLetBody(sb, structure, indent, indentSize, nestedLetDepth, maxLineLength, "=LET(");
+        return sb.ToString();
+    }
+
+    private static string FormatWrappedLet(string formula, int indentSize, int nestedLetDepth, int maxLineLength)
+    {
+        // Find pattern like =FUNC(LET(...)...)
+        // We need to find "LET(" that's inside another function call
+        var letIndex = formula.IndexOf("LET(", 1, StringComparison.OrdinalIgnoreCase);
+        if (letIndex == -1)
+        {
+            return formula;
+        }
+
+        // Extract the wrapper prefix (e.g., "=SUMPRODUCT(")
+        var prefix = formula.Substring(0, letIndex);
+
+        // Check that the prefix is like "=FUNC(" — ends with a function call opening
+        if (!prefix.TrimEnd().EndsWith("("))
+        {
+            return formula;
+        }
+
+        // Parse the inner LET
+        var innerLetFormula = "=" + formula.Substring(letIndex);
+        if (!LetFormulaParser.TryParse(innerLetFormula, out var structure) || structure == null)
+        {
+            return formula;
+        }
+
+        // Find the closing paren of the LET
+        var letOpenParen = letIndex + 3; // index of '(' in "LET("
+        var letCloseParen = LetArgumentSplitter.FindMatchingCloseParen(formula, letOpenParen);
+        if (letCloseParen == -1)
+        {
+            return formula;
+        }
+
+        // Get any suffix after the LET's closing paren (e.g., "))" for the wrapper)
+        var suffix = formula.Substring(letCloseParen + 1);
+
+        var sb = new StringBuilder();
+        sb.Append(prefix).Append("LET(");
+        var indent = new string(' ', indentSize);
+        FormatLetBody(sb, structure, indent, indentSize, nestedLetDepth, maxLineLength, prefix + "LET(");
+        sb.Append(suffix);
+        return sb.ToString();
+    }
+
+    private static void FormatLetBody(
+        StringBuilder sb,
+        LetStructure structure,
+        string indent,
+        int indentSize,
+        int remainingDepth,
+        int maxLineLength,
+        string openingLine)
+    {
+        var bindings = structure.Bindings;
+        var result = structure.ResultExpression.Trim();
+
+        // Try inlining with MaxLineLength > 0
+        if (maxLineLength > 0)
+        {
+            FormatWithInlining(sb, bindings, result, indent, indentSize, remainingDepth, maxLineLength, openingLine);
+            return;
+        }
+
+        // Default: always wrap every binding
+        sb.Append(NewLine);
+        for (var i = 0; i < bindings.Count; i++)
+        {
+            var name = bindings[i].VariableName.Trim();
+            var value = bindings[i].Value.Trim();
+            value = MaybeFormatNestedLet(value, indent, indentSize, remainingDepth);
+            sb.Append(indent).Append(name).Append(", ").Append(value).Append(',').Append(NewLine);
+        }
+
+        result = MaybeFormatNestedLet(result, indent, indentSize, remainingDepth);
+        sb.Append(indent).Append(result).Append(')');
+    }
+
+    private static void FormatWithInlining(
+        StringBuilder sb,
+        List<LetBinding> bindings,
+        string result,
+        string indent,
+        int indentSize,
+        int remainingDepth,
+        int maxLineLength,
+        string openingLine)
+    {
+        var currentLineLength = openingLine.Length;
+        var wrapping = false;
+        var firstOnLine = true;
+
+        for (var i = 0; i < bindings.Count; i++)
+        {
+            var name = bindings[i].VariableName.Trim();
+            var value = bindings[i].Value.Trim();
+            value = MaybeFormatNestedLet(value, indent, indentSize, remainingDepth);
+
+            // "name, value," is the binding text
+            var bindingText = name + ", " + value + ",";
+
+            if (!wrapping)
+            {
+                // Try to fit on current line
+                var spacer = firstOnLine ? "" : " ";
+                var wouldBe = currentLineLength + spacer.Length + bindingText.Length;
+                if (firstOnLine || wouldBe <= maxLineLength)
+                {
+                    sb.Append(spacer).Append(bindingText);
+                    currentLineLength += spacer.Length + bindingText.Length;
+                    firstOnLine = false;
+                }
+                else
+                {
+                    // This binding doesn't fit — start wrapping from here
+                    wrapping = true;
+                    sb.Append(NewLine);
+                    sb.Append(indent).Append(bindingText);
+                }
+            }
+            else
+            {
+                sb.Append(NewLine);
+                sb.Append(indent).Append(bindingText);
+            }
+        }
+
+        // Result expression
+        result = MaybeFormatNestedLet(result, indent, indentSize, remainingDepth);
+        if (!wrapping)
+        {
+            var spacer = firstOnLine ? "" : " ";
+            sb.Append(spacer).Append(result).Append(')');
+        }
+        else
+        {
+            sb.Append(NewLine);
+            sb.Append(indent).Append(result).Append(')');
+        }
+    }
+
+    /// <summary>
+    ///     If the value contains a nested LET and we have remaining depth, format it recursively.
+    /// </summary>
+    private static string MaybeFormatNestedLet(string value, string parentIndent, int indentSize, int remainingDepth)
+    {
+        if (remainingDepth <= 1)
+        {
+            return value;
+        }
+
+        // Check if the value is a LET(...) expression (possibly with whitespace)
+        var trimmed = value.TrimStart();
+        if (!trimmed.StartsWith("LET(", StringComparison.OrdinalIgnoreCase))
+        {
+            return value;
+        }
+
+        // Parse the nested LET
+        var nestedFormula = "=" + trimmed;
+        if (!LetFormulaParser.TryParse(nestedFormula, out var nestedStructure) || nestedStructure == null)
+        {
+            return value;
+        }
+
+        // Format recursively with deeper indent
+        var nestedIndent = parentIndent + new string(' ', indentSize);
+        var sb = new StringBuilder();
+        sb.Append("LET(");
+        // For nested LETs, always wrap (maxLineLength=0) to keep things readable
+        sb.Append(NewLine);
+        for (var i = 0; i < nestedStructure.Bindings.Count; i++)
+        {
+            var name = nestedStructure.Bindings[i].VariableName.Trim();
+            var val = nestedStructure.Bindings[i].Value.Trim();
+            val = MaybeFormatNestedLet(val, nestedIndent, indentSize, remainingDepth - 1);
+            sb.Append(nestedIndent).Append(name).Append(", ").Append(val).Append(',').Append(NewLine);
+        }
+
+        var nestedResult = nestedStructure.ResultExpression.Trim();
+        nestedResult = MaybeFormatNestedLet(nestedResult, nestedIndent, indentSize, remainingDepth - 1);
+        sb.Append(nestedIndent).Append(nestedResult).Append(')');
+
+        return sb.ToString();
+    }
+}

--- a/formula-boss/Interception/LetFormulaRewriter.cs
+++ b/formula-boss/Interception/LetFormulaRewriter.cs
@@ -21,7 +21,6 @@ public record ProcessedBinding(
 /// </summary>
 public static class LetFormulaRewriter
 {
-    private const string Indent = "    ";
     private const char NewLine = '\n'; // Use LF only - Excel COM doesn't like \r\n
 
     /// <summary>
@@ -29,12 +28,19 @@ public static class LetFormulaRewriter
     ///     and replacing backtick expressions with UDF calls.
     ///     Formats output with one binding per line for readability.
     /// </summary>
+    /// <param name="original">The parsed LET structure.</param>
+    /// <param name="processedBindings">Backtick bindings that were compiled to UDFs.</param>
+    /// <param name="processedResults">Backtick expressions in the result, if any.</param>
+    /// <param name="rewrittenResultExpression">Rewritten result expression referencing new bindings.</param>
+    /// <param name="indentSize">Number of spaces per indent level (default 4 for backwards compatibility).</param>
     public static string Rewrite(
         LetStructure original,
         IReadOnlyDictionary<string, ProcessedBinding> processedBindings,
         IReadOnlyList<ProcessedBinding>? processedResults = null,
-        string? rewrittenResultExpression = null)
+        string? rewrittenResultExpression = null,
+        int indentSize = 4)
     {
+        var indent = new string(' ', indentSize);
         var sb = new StringBuilder();
         sb.Append("=LET(").Append(NewLine);
 
@@ -45,17 +51,18 @@ public static class LetFormulaRewriter
             if (processedBindings.TryGetValue(variableName, out var processed))
             {
                 // This binding had a backtick expression - insert _src_ and UDF call
-                sb.Append(Indent).Append("_src_").Append(variableName).Append(", ");
-                sb.Append('"').Append(EscapeForExcelString(processed.OriginalExpression)).Append("\",").Append(NewLine);
+                sb.Append(indent).Append("_src_").Append(variableName).Append(", ");
+                sb.Append('"').Append(EscapeForExcelString(processed.OriginalExpression)).Append("\",")
+                    .Append(NewLine);
 
-                sb.Append(Indent).Append(variableName).Append(", ");
+                sb.Append(indent).Append(variableName).Append(", ");
                 AppendUdfCall(sb, processed);
                 sb.Append(',').Append(NewLine);
             }
             else
             {
                 // Normal binding - keep as-is
-                sb.Append(Indent).Append(binding.VariableName).Append(", ");
+                sb.Append(indent).Append(binding.VariableName).Append(", ");
                 sb.Append(binding.Value).Append(',').Append(NewLine);
             }
         }
@@ -66,22 +73,22 @@ public static class LetFormulaRewriter
             // Result expression had backtick(s) - add _src_ doc and binding for each
             foreach (var processedResult in processedResults)
             {
-                sb.Append(Indent).Append("_src_").Append(processedResult.VariableName).Append(", ");
+                sb.Append(indent).Append("_src_").Append(processedResult.VariableName).Append(", ");
                 sb.Append('"').Append(EscapeForExcelString(processedResult.OriginalExpression)).Append("\",")
                     .Append(NewLine);
 
-                sb.Append(Indent).Append(processedResult.VariableName).Append(", ");
+                sb.Append(indent).Append(processedResult.VariableName).Append(", ");
                 AppendUdfCall(sb, processedResult);
                 sb.Append(',').Append(NewLine);
             }
 
             // Final expression references the new bindings
-            sb.Append(Indent).Append(rewrittenResultExpression ?? processedResults[0].VariableName).Append(')');
+            sb.Append(indent).Append(rewrittenResultExpression ?? processedResults[0].VariableName).Append(')');
         }
         else
         {
             // Result expression is plain - keep as-is (no trailing comma)
-            sb.Append(Indent).Append(original.ResultExpression.Trim()).Append(')');
+            sb.Append(indent).Append(original.ResultExpression.Trim()).Append(')');
         }
 
         return sb.ToString();


### PR DESCRIPTION
## Summary

- Adds `LetFormulaFormatter` class that formats any LET formula with configurable indent size, nested LET depth, and max line length
- Makes `LetFormulaRewriter.Rewrite()` accept an `indentSize` parameter (was hardcoded 4 spaces), wired to `EditorSettings.IndentSize` in `FormulaInterceptor`
- 31 comprehensive unit tests covering: basic formatting, nested LETs at various depths, MaxLineLength inlining, string literals, array constants, backtick preservation, LET inside wrapper functions, and edge cases

Closes #265

## Test plan

- [x] All 836 existing tests pass (483 unit + 278 runtime + 34 integration + 41 addin)
- [x] 31 new formatter tests covering all spec scenarios
- [x] Tim: review ReSharper warnings after refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)