### PR TITLE
Replace reviewer agent with code-review skill

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,6 +1,15 @@
-# Reviewer — Formula Boss
+---
+name: code-review
+description: "Code review a pull request. Usage: /code-review <PR number>"
+---
+
+# Code Review — Formula Boss
 
 Review a PR for code quality and adherence to spec/plan.
+
+## Arguments
+
+- `/code-review <PR number>` — Review the specified pull request
 
 ## Instructions
 
@@ -14,11 +23,14 @@ Review a PR for code quality and adherence to spec/plan.
    - Are there tests? Are they meaningful?
    - Does it follow .NET 6 / C# 10 conventions (file-scoped namespaces, `_camelCase` fields)?
    - Any ExcelDNA assembly identity issues in generated code?
+   - Delegate bridge pattern used correctly (no host type references in bridge classes)?
+   - COM objects released properly via `Marshal.ReleaseComObject()`?
    - Any obvious bugs or edge cases?
 7. Report findings
 
 ## Output Format
 
+```markdown
 ### PR Review: #N — [title]
 
 **Plan Compliance:** [Good/Partial/Poor] — [brief note]
@@ -26,8 +38,10 @@ Review a PR for code quality and adherence to spec/plan.
 **Code Quality:** [observations]
 **Issues Found:** [list or "None"]
 **Recommendation:** [Approve / Request Changes / Needs Discussion]
+```
 
 ## Behaviour Notes
+
 - Do NOT write code or make changes
 - Do NOT merge PRs
 - Be constructive — flag issues but also note what's done well

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ This repo follows the [Taglo Claude Code workflow](https://github.com/TagloGit/t
 - `/planner <topic>` — Spec and plan creation (global skill)
 - `/pm` — Cross-repo status (global skill)
 - `/backlog-admin` — Quick issue creation (global skill)
-- Reviewer subagent — PR review (`.claude/agents/reviewer.md`)
+- `/code-review <pr>` — PR code review
 
 ### Specs and Plans
 - Specs: `specs/NNNN-short-title.md`


### PR DESCRIPTION
## Summary
- Add `/code-review` skill with repo-specific review criteria (.NET 6/C# 10 conventions, ExcelDNA assembly identity, delegate bridge pattern, COM lifecycle)
- Delete the unused agents directory (reviewer agent relied on broken auto-discovery)
- Update CLAUDE.md to reference the new skill

Part of TagloGit/taglo-pm#25

## Test plan
- [x] Verify `/code-review` skill appears in Claude Code session
- [x] Run `/code-review` against an existing PR to confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)