### PR TITLE
Thread origin context through Map() for Cell access

### DIFF
--- a/formula-boss.Runtime.Tests/ExcelArrayTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelArrayTests.cs
@@ -619,4 +619,53 @@ public class ExcelArrayTests
         Assert.Equal(30.0, resultArr[1, 0]);
         Assert.Equal(40.0, resultArr[1, 1]);
     }
+
+    [Fact]
+    public void Map_WithOrigin_ProvidesCellAccess()
+    {
+        RuntimeBridge.GetCell = (sheet, row, col) => new Cell
+        {
+            Value = $"{sheet}!R{row}C{col}",
+            Interior = new Interior(row + col, 0)
+        };
+        try
+        {
+            var origin = new RangeOrigin("Sheet1", 2, 3);
+            var data = new object?[,] { { 1.0, 2.0 }, { 3.0, 4.0 } };
+            var arr = new ExcelArray(data, origin: origin);
+
+            var colors = new List<int>();
+            arr.Map(x =>
+            {
+                colors.Add(x.Cell.Color);
+                return x;
+            });
+
+            // Row 0, Col 0 → origin (2,3) → color = 2+3 = 5
+            // Row 0, Col 1 → origin (2,4) → color = 2+4 = 6
+            // Row 1, Col 0 → origin (3,3) → color = 3+3 = 6
+            // Row 1, Col 1 → origin (3,4) → color = 3+4 = 7
+            Assert.Equal(new[] { 5, 6, 6, 7 }, colors);
+        }
+        finally
+        {
+            RuntimeBridge.GetCell = null;
+        }
+    }
+
+    [Fact]
+    public void Map_WithoutOrigin_CellThrows()
+    {
+        var data = new object?[,] { { 1.0 } };
+        var arr = new ExcelArray(data);
+
+        InvalidOperationException? caught = null;
+        arr.Map(x =>
+        {
+            caught = Assert.Throws<InvalidOperationException>(() => _ = x.Cell);
+            return x;
+        });
+
+        Assert.NotNull(caught);
+    }
 }

--- a/formula-boss.Runtime/ExcelArray.cs
+++ b/formula-boss.Runtime/ExcelArray.cs
@@ -196,7 +196,14 @@ public class ExcelArray : ExcelValue, IExcelRange
         for (var r = 0; r < rows; r++)
             for (var c = 0; c < cols; c++)
             {
-                var mapped = selector(new ExcelScalar(_data[r, c]));
+                var localR = r;
+                var localC = c;
+                Func<Cell>? cellAccessor = _origin != null && RuntimeBridge.GetCell != null
+                    ? () => RuntimeBridge.GetCell(_origin.SheetName,
+                        _origin.TopRow + localR, _origin.LeftCol + localC)
+                    : null;
+                var scalar = new ExcelScalar(_data[r, c]) { CellAccessor = cellAccessor };
+                var mapped = selector(scalar);
                 result[r, c] = mapped.RawValue is object?[,] arr ? arr[0, 0] : mapped.RawValue;
             }
 


### PR DESCRIPTION
## Summary

- Thread `RangeOrigin` + `RuntimeBridge.GetCell` through `ExcelArray.Map()` so each `ExcelScalar` passed to the lambda has a working `CellAccessor`
- Follows the same pattern as `Row.MakeScalar()` / `ExcelArray.Rows` getter
- Uses local variable copies (`localR`, `localC`) to avoid closure capture bugs with loop variables

Closes #281

## Test plan

- [x] `Map_WithOrigin_ProvidesCellAccess` — verifies `.Cell.Color` returns correct position-based values inside Map lambda
- [x] `Map_WithoutOrigin_CellThrows` — verifies `.Cell` throws `InvalidOperationException` when no origin
- [x] All 850 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)