### PR TITLE
Add generic Map<TResult> overload

### DIFF
--- a/formula-boss.Runtime.Tests/ExcelArrayTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelArrayTests.cs
@@ -668,4 +668,70 @@ public class ExcelArrayTests
 
         Assert.NotNull(caught);
     }
+
+    // --- Map<TResult> ---
+
+    [Fact]
+    public void MapGeneric_ReturnsInt()
+    {
+        var arr = new ExcelArray(new object?[,] { { 1.0, 2.0 }, { 3.0, 4.0 } });
+        var result = arr.Map(x => (int)(double)x);
+        var resultArr = (object?[,])((ExcelValue)result).RawValue!;
+        Assert.Equal(1, resultArr[0, 0]);
+        Assert.Equal(2, resultArr[0, 1]);
+        Assert.Equal(3, resultArr[1, 0]);
+        Assert.Equal(4, resultArr[1, 1]);
+    }
+
+    [Fact]
+    public void MapGeneric_ReturnsString()
+    {
+        var arr = new ExcelArray(new object?[,] { { 1.0, 2.0 } });
+        var result = arr.Map(x => $"val:{x}");
+        var resultArr = (object?[,])((ExcelValue)result).RawValue!;
+        Assert.Equal("val:1", resultArr[0, 0]);
+        Assert.Equal("val:2", resultArr[0, 1]);
+    }
+
+    [Fact]
+    public void MapGeneric_Preserves2DShape()
+    {
+        var arr = new ExcelArray(new object?[,] { { 1.0, 2.0 }, { 3.0, 4.0 } });
+        var result = arr.Map(x => (double)x > 2.0);
+        var resultArr = (object?[,])((ExcelValue)result).RawValue!;
+        Assert.Equal(2, resultArr.GetLength(0));
+        Assert.Equal(2, resultArr.GetLength(1));
+        Assert.Equal(false, resultArr[0, 0]);
+        Assert.Equal(false, resultArr[0, 1]);
+        Assert.Equal(true, resultArr[1, 0]);
+        Assert.Equal(true, resultArr[1, 1]);
+    }
+
+    [Fact]
+    public void MapGeneric_WithOrigin_ProvidesCellAccess()
+    {
+        RuntimeBridge.GetCell = (sheet, row, col) => new Cell
+        {
+            Value = $"{sheet}!R{row}C{col}",
+            Interior = new Interior(row + col, 0)
+        };
+        try
+        {
+            var origin = new RangeOrigin("Sheet1", 2, 3);
+            var data = new object?[,] { { 1.0, 2.0 }, { 3.0, 4.0 } };
+            var arr = new ExcelArray(data, origin: origin);
+
+            var result = arr.Map(x => x.Cell.Color);
+            var resultArr = (object?[,])((ExcelValue)result).RawValue!;
+
+            Assert.Equal(5, resultArr[0, 0]);  // 2+3
+            Assert.Equal(6, resultArr[0, 1]);  // 2+4
+            Assert.Equal(6, resultArr[1, 0]);  // 3+3
+            Assert.Equal(7, resultArr[1, 1]);  // 3+4
+        }
+        finally
+        {
+            RuntimeBridge.GetCell = null;
+        }
+    }
 }

--- a/formula-boss.Runtime.Tests/ExcelScalarTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelScalarTests.cs
@@ -214,6 +214,31 @@ public class ExcelScalarTests
     }
 
     [Fact]
+    public void MapGeneric_ReturnsInt()
+    {
+        var scalar = new ExcelScalar(5.0);
+        var result = scalar.Map(v => (int)(double)v * 2);
+        Assert.Equal(10, ((ExcelValue)result).RawValue);
+    }
+
+    [Fact]
+    public void MapGeneric_ReturnsString()
+    {
+        var scalar = new ExcelScalar(42.0);
+        var result = scalar.Map(v => $"answer:{v}");
+        Assert.Equal("answer:42", ((ExcelValue)result).RawValue);
+    }
+
+    [Fact]
+    public void MapGeneric_WithExcelValueResult_ReturnsDirectly()
+    {
+        var scalar = new ExcelScalar(5.0);
+        var result = scalar.Map(v => (ExcelValue)new ExcelScalar((double)v + 1));
+        Assert.IsType<ExcelScalar>(result);
+        Assert.Equal(6.0, ((ExcelValue)result).RawValue);
+    }
+
+    [Fact]
     public void OrderBy_ReturnsSelf()
     {
         var scalar = new ExcelScalar(42.0);

--- a/formula-boss.Runtime/ExcelArray.cs
+++ b/formula-boss.Runtime/ExcelArray.cs
@@ -210,6 +210,27 @@ public class ExcelArray : ExcelValue, IExcelRange
         return new ExcelArray(result, ColumnMap);
     }
 
+    public override IExcelRange Map<TResult>(Func<ExcelScalar, TResult> selector)
+    {
+        var rows = _data.GetLength(0);
+        var cols = _data.GetLength(1);
+        var result = new object?[rows, cols];
+        for (var r = 0; r < rows; r++)
+            for (var c = 0; c < cols; c++)
+            {
+                var localR = r;
+                var localC = c;
+                Func<Cell>? cellAccessor = _origin != null && RuntimeBridge.GetCell != null
+                    ? () => RuntimeBridge.GetCell(_origin.SheetName,
+                        _origin.TopRow + localR, _origin.LeftCol + localC)
+                    : null;
+                var scalar = new ExcelScalar(_data[r, c]) { CellAccessor = cellAccessor };
+                result[r, c] = selector(scalar);
+            }
+
+        return new ExcelArray(result, ColumnMap);
+    }
+
     public override IExcelRange OrderBy(Func<ExcelScalar, object> keySelector)
     {
         var elements = ElementWise().OrderBy(e => keySelector(e)).ToList();

--- a/formula-boss.Runtime/ExcelScalar.cs
+++ b/formula-boss.Runtime/ExcelScalar.cs
@@ -125,6 +125,12 @@ public class ExcelScalar : ExcelValue, IExcelRange
         return result;
     }
 
+    public override IExcelRange Map<TResult>(Func<ExcelScalar, TResult> selector)
+    {
+        var result = selector(this);
+        return result is ExcelValue ev ? (IExcelRange)ev : new ExcelScalar(result);
+    }
+
     public override IExcelRange OrderBy(Func<ExcelScalar, object> keySelector) => this;
     public override IExcelRange OrderByDescending(Func<ExcelScalar, object> keySelector) => this;
     public override IExcelRange Take(int count) => count == 0 ? new ExcelArray(new object[0, 0]) : this;

--- a/formula-boss.Runtime/ExcelValue.cs
+++ b/formula-boss.Runtime/ExcelValue.cs
@@ -99,6 +99,9 @@ public abstract class ExcelValue : IExcelRange, IComparable<ExcelValue>, ICompar
     public abstract IExcelRange Map(Func<ExcelScalar, ExcelScalar> selector);
 
     /// <inheritdoc />
+    public abstract IExcelRange Map<TResult>(Func<ExcelScalar, TResult> selector);
+
+    /// <inheritdoc />
     public abstract IExcelRange OrderBy(Func<ExcelScalar, object> keySelector);
 
     /// <inheritdoc />

--- a/formula-boss.Runtime/IExcelRange.cs
+++ b/formula-boss.Runtime/IExcelRange.cs
@@ -73,6 +73,12 @@ public interface IExcelRange : IEnumerable<ExcelValue>
     /// <returns>A new range with the same dimensions, containing transformed values.</returns>
     IExcelRange Map(Func<ExcelScalar, ExcelScalar> selector);
 
+    /// <summary>Applies a function to each element, boxing the result directly into the output array.</summary>
+    /// <typeparam name="TResult">The return type of the selector.</typeparam>
+    /// <param name="selector">A function that transforms each element.</param>
+    /// <returns>A new range with the same dimensions, containing transformed values.</returns>
+    IExcelRange Map<TResult>(Func<ExcelScalar, TResult> selector);
+
     /// <summary>Sorts elements in ascending order by the selected key.</summary>
     /// <param name="keySelector">A function that extracts a sort key from each element.</param>
     IExcelRange OrderBy(Func<ExcelScalar, object> keySelector);


### PR DESCRIPTION
## Summary

- Adds `IExcelRange Map<TResult>(Func<ExcelScalar, TResult> selector)` to `IExcelRange`, `ExcelValue`, `ExcelArray`, and `ExcelScalar`
- Generic overload boxes `TResult` directly into the result array (unlike non-generic Map which unwraps `ExcelScalar.RawValue`)
- Threads origin context through the generic overload for `.Cell` access in lambdas
- Adds 7 unit tests covering int/string/bool returns, 2D shape preservation, origin-based Cell access, and ExcelValue passthrough

Closes #282

## Test plan

- [x] All 295 runtime unit tests pass
- [x] Tim: review ReSharper warnings after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)