### PR TITLE
Remove custom Select/SelectMany and update spec for Map + Cell

### DIFF
--- a/formula-boss.AddinTests/PipelineTests.cs
+++ b/formula-boss.AddinTests/PipelineTests.cs
@@ -1378,6 +1378,45 @@ public class PipelineTests
     }
 
     [Fact]
+    public void Map_CellColor_Returns2DColorIndices()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            // Set up a 2x2 grid with different colors
+            TestUtilities.SetCellValue(ws, "A1", 1.0);
+            TestUtilities.SetCellValue(ws, "B1", 2.0);
+            TestUtilities.SetCellValue(ws, "A2", 3.0);
+            TestUtilities.SetCellValue(ws, "B2", 4.0);
+
+            // Color cells: A1=yellow(6), B1=red(3), A2=green(4), B2=yellow(6)
+            TestUtilities.SetCellColor(ws, "A1", 6);
+            TestUtilities.SetCellColor(ws, "B1", 3);
+            TestUtilities.SetCellColor(ws, "A2", 4);
+            TestUtilities.SetCellColor(ws, "B2", 6);
+
+            TestUtilities.EnterBacktickFormula(ws, "D1", "=`A1:B2.Map(c => c.Cell.Color)`");
+
+            var result = TestUtilities.WaitForResult(ws, "D1", _output);
+
+            _output.WriteLine($"D1 formula: {TestUtilities.GetCellFormula(ws, "D1")}");
+            _output.WriteLine($"D1={TestUtilities.GetCellValue(ws, "D1")}, E1={TestUtilities.GetCellValue(ws, "E1")}");
+            _output.WriteLine($"D2={TestUtilities.GetCellValue(ws, "D2")}, E2={TestUtilities.GetCellValue(ws, "E2")}");
+            _output.WriteLine($"D1 comment: {TestUtilities.GetCellComment(ws, "D1")}");
+
+            Assert.NotNull(result);
+            Assert.Equal(6.0, Convert.ToDouble(TestUtilities.GetCellValue(ws, "D1")));
+            Assert.Equal(3.0, Convert.ToDouble(TestUtilities.GetCellValue(ws, "E1")));
+            Assert.Equal(4.0, Convert.ToDouble(TestUtilities.GetCellValue(ws, "D2")));
+            Assert.Equal(6.0, Convert.ToDouble(TestUtilities.GetCellValue(ws, "E2")));
+        }
+        finally
+        {
+            TestUtilities.CleanupWorksheet(ws);
+        }
+    }
+
+    [Fact]
     public void Table_ColumnAccess_Sum()
     {
         var ws = _excel.AddWorksheet();

--- a/formula-boss.Runtime.Tests/ExcelArrayTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelArrayTests.cs
@@ -115,17 +115,16 @@ public class ExcelArrayTests
         Assert.Null(result);
     }
 
-    // --- Element-wise Select ---
+    // --- LINQ Select (formerly custom Select, now falls through to Enumerable.Select) ---
 
     [Fact]
-    public void Select_TransformsCellsElementWise()
+    public void Select_ViaLinq_TransformsCellsElementWise()
     {
         var arr = MakeSingleColumn();
-        var result = arr.Select(v => new ExcelScalar((double)v * 10));
-        var rows = result.Rows.ToList();
-        Assert.Equal(3, rows.Count);
-        Assert.Equal(10.0, (double)rows[0][0]);
-        Assert.Equal(30.0, (double)rows[2][0]);
+        var result = arr.Select(v => (double)v * 10).ToList();
+        Assert.Equal(3, result.Count);
+        Assert.Equal(10.0, result[0]);
+        Assert.Equal(30.0, result[2]);
     }
 
     // --- Element-wise OrderBy ---
@@ -341,15 +340,15 @@ public class ExcelArrayTests
         Assert.Equal((6.0, 2, 1), visited[5]);
     }
 
-    // --- SelectMany ---
+    // --- LINQ SelectMany (formerly custom SelectMany) ---
 
     [Fact]
-    public void SelectMany_FlattensResults()
+    public void SelectMany_ViaLinq_FlattensResults()
     {
         var arr = new ExcelArray(new object?[,] { { 1.0 }, { 2.0 } });
         var result = arr.SelectMany(v =>
-            new ExcelValue[] { new ExcelScalar((double)v), new ExcelScalar((double)v * 10) });
-        Assert.Equal(4, result.Count());
+            new[] { (double)v, (double)v * 10 }).ToList();
+        Assert.Equal(4, result.Count);
     }
 
     // --- Empty array edge cases ---

--- a/formula-boss.Runtime.Tests/ExcelScalarTests.cs
+++ b/formula-boss.Runtime.Tests/ExcelScalarTests.cs
@@ -197,12 +197,12 @@ public class ExcelScalarTests
     }
 
     [Fact]
-    public void SelectMany_FlattensResults()
+    public void SelectMany_ViaLinq_FlattensResults()
     {
         var scalar = new ExcelScalar(3.0);
         var result = scalar.SelectMany(v =>
-            new ExcelValue[] { new ExcelScalar((double)v), new ExcelScalar((double)v * 10) });
-        Assert.Equal(2, result.Count());
+            new[] { (double)v, (double)v * 10 }).ToList();
+        Assert.Equal(2, result.Count);
     }
 
     [Fact]

--- a/formula-boss.Runtime/ExcelArray.cs
+++ b/formula-boss.Runtime/ExcelArray.cs
@@ -128,35 +128,6 @@ public class ExcelArray : ExcelValue, IExcelRange
         return new ExcelArray(array);
     }
 
-    public override IExcelRange Select(Func<ExcelValue, ExcelValue> selector)
-    {
-        var results = ElementWise().Select(e => selector(e)).ToList();
-        if (results.Count == 0)
-        {
-            return new ExcelArray(new object?[0, 1]);
-        }
-
-        var array = new object?[results.Count, 1];
-        for (var i = 0; i < results.Count; i++)
-        {
-            array[i, 0] = results[i].RawValue is object?[,] arr ? arr[0, 0] : results[i].RawValue;
-        }
-
-        return new ExcelArray(array);
-    }
-
-    public override IExcelRange SelectMany(Func<ExcelValue, IEnumerable<ExcelValue>> selector)
-    {
-        var results = ElementWise().SelectMany(e => selector(e)).ToList();
-        var array = new object?[results.Count, 1];
-        for (var i = 0; i < results.Count; i++)
-        {
-            array[i, 0] = results[i].RawValue;
-        }
-
-        return new ExcelArray(array);
-    }
-
     public override bool Any(Func<ExcelScalar, bool> predicate) =>
         ElementWise().Any(e => predicate(e));
 

--- a/formula-boss.Runtime/ExcelScalar.cs
+++ b/formula-boss.Runtime/ExcelScalar.cs
@@ -86,24 +86,6 @@ public class ExcelScalar : ExcelValue, IExcelRange
     public override IExcelRange Where(Func<ExcelScalar, bool> predicate) =>
         predicate(this) ? this : new ExcelArray(new object[0, 0]);
 
-    public override IExcelRange Select(Func<ExcelValue, ExcelValue> selector)
-    {
-        var result = selector(this);
-        return result;
-    }
-
-    public override IExcelRange SelectMany(Func<ExcelValue, IEnumerable<ExcelValue>> selector)
-    {
-        var results = selector(this).ToList();
-        var array = new object?[results.Count, 1];
-        for (var i = 0; i < results.Count; i++)
-        {
-            array[i, 0] = results[i].RawValue;
-        }
-
-        return new ExcelArray(array);
-    }
-
     public override bool Any(Func<ExcelScalar, bool> predicate) => predicate(this);
     public override bool All(Func<ExcelScalar, bool> predicate) => predicate(this);
 

--- a/formula-boss.Runtime/ExcelValue.cs
+++ b/formula-boss.Runtime/ExcelValue.cs
@@ -63,12 +63,6 @@ public abstract class ExcelValue : IExcelRange, IComparable<ExcelValue>, ICompar
     public abstract IExcelRange Where(Func<ExcelScalar, bool> predicate);
 
     /// <inheritdoc />
-    public abstract IExcelRange Select(Func<ExcelValue, ExcelValue> selector);
-
-    /// <inheritdoc />
-    public abstract IExcelRange SelectMany(Func<ExcelValue, IEnumerable<ExcelValue>> selector);
-
-    /// <inheritdoc />
     public abstract bool Any(Func<ExcelScalar, bool> predicate);
 
     /// <inheritdoc />

--- a/formula-boss.Runtime/IExcelRange.cs
+++ b/formula-boss.Runtime/IExcelRange.cs
@@ -27,16 +27,6 @@ public interface IExcelRange : IEnumerable<ExcelValue>
     /// <returns>A new range containing only matching elements.</returns>
     IExcelRange Where(Func<ExcelScalar, bool> predicate);
 
-    /// <summary>Projects each element into a new value.</summary>
-    /// <param name="selector">A function that transforms each element.</param>
-    /// <returns>A new range containing the transformed values.</returns>
-    IExcelRange Select(Func<ExcelValue, ExcelValue> selector);
-
-    /// <summary>Projects each element to a sequence and flattens the results.</summary>
-    /// <param name="selector">A function that returns a sequence for each element.</param>
-    /// <returns>A new range containing all flattened values.</returns>
-    IExcelRange SelectMany(Func<ExcelValue, IEnumerable<ExcelValue>> selector);
-
     /// <summary>Returns true if any element matches the predicate.</summary>
     /// <param name="predicate">A function to test each element.</param>
     bool Any(Func<ExcelScalar, bool> predicate);

--- a/specs/0005-formula-boss-user-spec.md
+++ b/specs/0005-formula-boss-user-spec.md
@@ -165,7 +165,7 @@ Headers are extracted from the first row of the range. When using Excel Tables (
 
 ### Element-Wise Operations (on ExcelValue / IExcelRange)
 
-These iterate over all values in row-major order (left-to-right, top-to-bottom). The lambda parameter is `ExcelValue`:
+These iterate over all values in row-major order (left-to-right, top-to-bottom). The lambda parameter is `ExcelScalar`:
 
 | Operation | Returns | Description |
 |---|---|---|
@@ -173,6 +173,7 @@ These iterate over all values in row-major order (left-to-right, top-to-bottom).
 | `.Select(x => expr)` | `IExcelRange` | Project elements (flattens to 1 column) |
 | `.SelectMany(x => seq)` | `IExcelRange` | Flatten nested sequences |
 | `.Map(x => expr)` | `IExcelRange` | Transform elements (preserves 2D shape) |
+| `.Map<TResult>(x => expr)` | `IExcelRange` | Transform elements to non-ExcelScalar type (e.g. `int`, `string`) |
 | `.Any(x => pred)` | `bool` | True if any element matches |
 | `.All(x => pred)` | `bool` | True if all elements match |
 | `.First(x => pred)` | `ExcelValue` | First matching element |
@@ -366,6 +367,11 @@ The floating editor provides Roslyn-powered autocomplete:
 ### Element-wise transform preserving shape
 ```
 '=`myRange.Map(x => x * 1.1)`
+```
+
+### Map cell colors to values
+```
+'=`maze.Map(c => c.Cell.Color)`
 ```
 
 ### Conditional with statement block


### PR DESCRIPTION
## Summary
- Remove custom `Select` and `SelectMany` from `IExcelRange`/`ExcelValue`/`ExcelScalar`/`ExcelArray` — LINQ fallback handles these (#283)
- Update user spec: element-wise lambda param is `ExcelScalar`, add `Map<TResult>` overload, add `maze.Map(c => c.Cell.Color)` example (#284)
- Add end-to-end AddIn test for `Map + Cell.Color` on a 2D colored range (#284)

Closes #283
Closes #284

## Test plan
- [x] All 857 unit/integration tests pass
- [x] 42/43 AddIn tests pass (1 flaky COM timeout on `ValuePath_Any_False` — pre-existing, unrelated)
- [x] New `Map_CellColor_Returns2DColorIndices` AddIn test passes — verifies 2D color index extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)