### PR TITLE
Add spec and plan for 0015 trace debugging

### DIFF
--- a/plans/0015-trace-debugging.md
+++ b/plans/0015-trace-debugging.md
@@ -1,0 +1,59 @@
+# 0015 — Trace Debugging — Implementation Plan
+
+## Overview
+
+Add a **debug mode** to the FB transpile pipeline that emits an instrumented variant of each compiled UDF (`__FB_<NAME>_DEBUG`) alongside the normal one. The debug variant records a per-iteration / per-return snapshot of every in-scope local into a per-cell buffer. A companion UDF `=FB.LastTrace()` spills the most recent buffer as a 2D array.
+
+The toggle is per-cell in the floating editor. Toggling rewrites call sites in the LET formula (`__FB_FOO(...)` ↔ `__FB_FOO_DEBUG(...)`) without touching the `_src_foo` source string literal. Because the cell's call site is the mode indicator, debug mode survives file reopen with no hidden state.
+
+The implementation splits cleanly into five PR-sized tasks that stack on each other: (1) the `Tracer` runtime bridge, (2) the `DebugInstrumentationRewriter` that emits snapshot calls, (3) the compile/register path for `_DEBUG` variants plus `FB.LastTrace`, (4) the editor toggle UI and call-site rewriter, and (5) workbook-open rehydration + integration tests.
+
+## Files to Touch
+
+### New files
+
+- `formula-boss.Runtime/Tracer.cs` — buffer + delegate bridge class. Public static API: `Begin(name, callerAddr)`, `Set(name, value)`, `Snapshot(kind, depth, branch)`, `Return(value)`, `TruncateWarn()`. Static `LastBuffer` keyed by caller address. Delegate fields follow the `RuntimeBridge` pattern (only `object`/primitives in signatures).
+- `formula-boss/Transpilation/DebugInstrumentationRewriter.cs` — `CSharpSyntaxRewriter` that wraps the user's statement block: inserts `Tracer.Begin`, `Tracer.Set` after each `LocalDeclarationStatement` and `AssignmentExpressionStatement`, `Tracer.Snapshot("iter", depth, branchLabel)` at the end of each loop body, `Tracer.Snapshot("return", ..)` + return-value capture around each `ReturnStatement`, and branch labelling on `IfStatement`/`ElseClause` arms. Tracks loop depth via a visit counter. Extracts branch labels from the first statement of each arm (truncated to 20 chars).
+- `formula-boss/LastTraceUdf.cs` — hosts the `FB.LastTrace()` `[ExcelFunction]` static. Returns `Tracer.LastBuffer.ToObjectArray()` or `"#N/A — no trace captured"` if empty.
+- `formula-boss.Tests/DebugInstrumentationRewriterTests.cs` — unit tests asserting emitted source shape for representative inputs (simple foreach, nested foreach, if/else, return inside loop, early return).
+- `formula-boss.Tests/TracerTests.cs` — unit tests for buffer behaviour: row cap at 1000 + truncation-warning row, column union across snapshots, cell keying, clear-on-Begin.
+- `formula-boss.AddinTests/DebugModeTests.cs` — end-to-end: enter a formula, toggle debug, assert `FB.LastTrace()` spills the expected table; toggle off, assert call site reverts.
+
+### Modified files
+
+- `formula-boss/Transpilation/TranspileResult.cs` — add `DebugSourceCode` field (or a parallel `TranspileResult DebugVariant` property). The normal path is unchanged; debug mode is an explicit second compile pass.
+- `formula-boss/Transpilation/CodeEmitter.cs` — add `EmitDebug(...)` path that runs `DebugInstrumentationRewriter` over the user block before emission, and generates the `__FB_<NAME>_DEBUG` method name (new constant `DebugSuffix = "_DEBUG"`).
+- `formula-boss/Compilation/DynamicCompiler.cs` — add `CompileAndRegisterDebug(...)` that compiles the debug variant and registers the `_DEBUG` delegate. Called from the pipeline when debug mode is requested for a cell.
+- `formula-boss/Interception/LetFormulaReconstructor.cs` — add helpers: `RewriteCallSitesToDebug(formula, names)` and `RewriteCallSitesToNormal(formula, names)` that flip `__FB_<NAME>(` ↔ `__FB_<NAME>_DEBUG(` without touching `_src_<name>` strings. Add `GetDebugCallSites(formula)` returning the names of any `_DEBUG` call sites present (for open-workbook rehydration).
+- `formula-boss/Commands/ShowFloatingEditorCommand.cs` — no direct changes; the toggle is wired through the editor view, which calls into a new `DebugToggleService`.
+- `formula-boss/UI/Editor/*` (exact file per the editor's current structure) — add a **Debug** toolbar button + `Ctrl+D` binding on the floating editor. The button's `IsChecked` state reflects whether the current cell's formula already has `_DEBUG` call sites.
+- `formula-boss/UI/RibbonController.cs` — no change needed (toggle lives in the floating editor, not the ribbon).
+- `formula-boss/AddIn.cs` — in `AutoOpen()`, initialise the `Tracer` delegate bridge (same pattern as `RuntimeHelpers` / `RuntimeBridge`). On workbook open, scan active sheets for cells whose formulas contain `__FB_*_DEBUG(` and ensure the debug variant is compiled. (Keep this scan minimal — only cells discovered via a cheap scan of the used range; defer heavy discovery if perf becomes an issue.)
+- `formula-boss.dna` — add `Pack="false"` / ensure `formula-boss.Runtime.dll` is shipped so the `Tracer` bridge loads correctly (already the case per CLAUDE.md).
+
+## Order of Operations
+
+1. **Task 1 — `Tracer` runtime bridge.** Add `Tracer.cs` to `formula-boss.Runtime`. Implement the buffer (dictionary of column name → list of values, plus `kind`, `depth`, `branch`, `return` columns), row cap + truncation row, cell-address keying, and `ToObjectArray()` that produces `object[,]` with header row. Wire `Tracer` delegate-bridge initialisation from `AddIn.AutoOpen`. Unit tests in `TracerTests.cs`. **Rationale:** this is the foundation — everything else calls into it.
+
+2. **Task 2 — `DebugInstrumentationRewriter`.** Add the rewriter and `EmitDebug` path in `CodeEmitter`. No compile/register wiring yet — tests assert the emitted *source string* shape. Cover: simple statements, `foreach`, nested `foreach` (depth tracking), `if/else` (branch labels), `return` statements. **Rationale:** pure syntactic transform, easy to test in isolation, biggest correctness risk in the whole feature.
+
+3. **Task 3 — Compile/register `_DEBUG` variants + `FB.LastTrace()` UDF.** Add `DynamicCompiler.CompileAndRegisterDebug`. Add `LastTraceUdf.cs` and register it at add-in startup (same path as any other static `[ExcelFunction]`). At this point you can manually rewrite a cell's formula to `__FB_FOO_DEBUG(...)` in the Excel formula bar and see `=FB.LastTrace()` spill. **Rationale:** end-to-end compile path working before any UI is built — de-risks tasks 4 and 5.
+
+4. **Task 4 — Editor toggle UI + call-site rewriter.** Add **Debug** button + `Ctrl+D` in the floating editor. Wire to a new `DebugToggleService` that: reads the active cell's formula, uses `LetFormulaReconstructor` helpers to flip call sites, triggers compile of the `_DEBUG` variant via task 3's path, and writes the updated formula back. Button state reflects current mode by scanning for `_DEBUG` call sites. **Rationale:** this is the user-visible surface and depends on everything before it.
+
+5. **Task 5 — Workbook-open rehydration + AddinTests.** On `WorkbookOpen`, scan used ranges for `__FB_*_DEBUG(` and compile the debug variant for each found name (source from the cell's `_src_<name>` literal). Add end-to-end AddinTests using the scoring-loop example from the spec: enter formula, toggle debug, assert `FB.LastTrace()` spill contents match expected rows/cols; edit source while in debug mode, assert both variants recompile; toggle off, assert call site reverts. **Rationale:** closes the loop on "survives file reopen" and provides the acceptance-criteria proof.
+
+## Testing Approach
+
+- **Unit (`formula-boss.Tests`):**
+  - `DebugInstrumentationRewriterTests` — assert on emitted source for each construct. Keep assertions loose (regex or "contains `Tracer.Snapshot(\"iter\"`") rather than exact string match, so trivial formatting changes don't break tests.
+  - `TracerTests` — buffer mechanics, row cap, truncation row, column union, cell keying, clear-on-Begin.
+  - `LetFormulaReconstructorTests` — add cases for `RewriteCallSitesToDebug` / `RewriteCallSitesToNormal` round-tripping, and ensure `_src_` literals are not touched.
+
+- **Integration (`formula-boss.AddinTests`):**
+  - `DebugModeTests.ScoringLoop_TogglesAndTraces` — uses the spec's scoring-loop example. Enters the formula, invokes the toggle service (or simulates `Ctrl+D`), asserts `FB.LastTrace()` spills a table with the expected columns and at least the expected first few rows.
+  - `DebugModeTests.ToggleOff_RevertsCallSite` — assert call site reverts and `FB.LastTrace()` still shows the last captured buffer (buffer is not cleared on toggle-off).
+  - `DebugModeTests.ReopenWorkbook_RehydratesDebugVariant` — write a workbook with a `_DEBUG` call site, close+reopen, assert no `#NAME?` and `FB.LastTrace()` works after recalc.
+  - `DebugModeTests.EditSourceWhileDebugging_RecompilesBoth` — edit the source, assert both normal and debug variants are compiled (toggle off is instant).
+
+- **Perf sanity check (manual, noted in task 3 acceptance):** time a compile of a medium expression with and without the debug pass; a regression >2× indicates the rewriter needs attention. No automated perf test.

--- a/specs/0015-trace-debugging.md
+++ b/specs/0015-trace-debugging.md
@@ -1,0 +1,79 @@
+# 0015 — Trace Debugging ("LINQPad-style dumps")
+
+## Problem
+
+Formula Boss lets users write inline C# expressions that transpile to UDFs. When a result is wrong, the user has no visibility into intermediate state: local variables, loop iterations, which branch of an `if/else` fired. Real debugger attach (VS on the Excel process) is a power-user workflow that requires tooling outside Excel and breaks the "stay in the sheet" ergonomics.
+
+A typical bug involves iterating over an array while maintaining a handful of counters and branching on conditions — e.g. a scoring loop that tracks per-player scores and turn counts. When the answer is wrong, the user currently has to reason about the code statically, add scratch cells, or rewrite the expression to return intermediate state. All of these lose the loop structure.
+
+## Proposed Solution
+
+A **trace mode** for compiled expressions. The transpiler emits an instrumented variant of the UDF that records a snapshot of every in-scope local at each loop iteration and at each `return`, into a per-cell buffer. The user spills the buffer as a 2D array via a companion UDF `=FB.LastTrace()`.
+
+Debug mode is toggled per cell via a button / hotkey in the floating editor. Toggling rewrites the cell's call site from `__FB_FOO(...)` to `__FB_FOO_DEBUG(...)`, leaving the `_src_foo` source string literal (which the LET formula already carries) untouched. No hidden editor state — the cell's current call site *is* the mode indicator, so debug mode survives file reopen.
+
+### End-to-end workflow
+
+1. User opens the floating editor on a cell whose answer looks wrong.
+2. User presses **Debug** (toolbar button or `Ctrl+D`).
+3. FB parses the cell formula, finds `_src_<name>` literals, transpiles each in debug mode, compiles and registers `__FB_<NAME>_DEBUG` delegates, and rewrites the cell's call sites to the `_DEBUG` variants.
+4. Excel recalcs. The cell still shows its real answer; the tracer has populated a buffer keyed by the calling cell.
+5. User types `=FB.LastTrace()` in an empty cell; it spills a table — one row per loop iteration (plus entry and return rows), one column per local variable plus a `branch` column.
+6. User identifies the bug by scanning the trace, edits the source, recompiles. While the cell is in debug mode, recompiles keep producing the `_DEBUG` variant.
+7. User presses **Debug** again to toggle off. FB rewrites the call site back to `__FB_<NAME>` and drops the debug delegate.
+
+### What the transpiler emits in debug mode
+
+For each compiled expression:
+- At entry: `Tracer.Begin(name)` and an initial snapshot tagged `"entry"` capturing every declared local.
+- After each local declaration / assignment: record the new value against the local's name.
+- At the top of each loop body: bind the loop variable as a tracked local.
+- At the end of each loop body: `Tracer.Snapshot("iter")` — copies the current variable map as one row.
+- At each `return`: `Tracer.Snapshot("return")` before the return executes, capturing the final state and the returned value.
+- Around each `if/else` arm: tag the arm with a short label (the first statement, truncated) so a `branch` column can be populated.
+
+`Tracer` is a bridge class in `FormulaBoss.Runtime` following the existing delegate-bridge pattern (no host-loaded types in its public surface).
+
+### Buffer lifecycle
+
+- One buffer per calling cell (keyed by `xlfCaller` address).
+- Cleared at the start of each invocation of a `_DEBUG` UDF.
+- `FB.LastTrace()` (no args) returns the most recently populated buffer as `object[,]`.
+- Columns are the union of locals ever snapshotted in that run; missing values render as blank.
+- Nested loops flatten into a single table with a `depth` column indicating the loop nesting level (0 = outermost).
+- `return` rows include the returned value in a dedicated `return` column.
+- Hard cap of 1000 snapshot rows per run. On overflow, a final truncation-warning row is appended and further snapshots are dropped.
+- Branch labels are derived from the first statement of the arm, truncated to ~20 chars.
+- When the user edits a cell that is currently in debug mode, FB recompiles both the normal and `_DEBUG` variants so toggling off is instant.
+
+## User Stories
+
+- As a Formula Boss user, when my expression returns the wrong answer, I want to see the value of every local at every loop iteration so I can find where the state diverges from what I expected.
+- As a Formula Boss user, I want to toggle debug mode on one cell without editing the source, so I can investigate without risking changes to a working formula.
+- As a Formula Boss user, I want debug mode to survive a file reopen so I can come back to a debugging session without re-setting it up.
+- As a Formula Boss user, I want the trace output to appear as a normal spilled array in the sheet so I can filter, sort, and inspect it with familiar Excel tools.
+- As a Formula Boss user, I want zero perf cost in non-debug mode, so I can leave production formulas untouched.
+
+## Acceptance Criteria
+
+- [ ] A **Debug** toggle (button + `Ctrl+D`) exists in the floating editor, enabled when the current cell has one or more `_src_<name>` literals.
+- [ ] Toggling debug **on** rewrites each `__FB_<NAME>(...)` call site in the cell formula to `__FB_<NAME>_DEBUG(...)`, compiles and registers the debug delegate, and leaves `_src_<name>` strings untouched.
+- [ ] Toggling debug **off** rewrites `__FB_<NAME>_DEBUG(...)` back to `__FB_<NAME>(...)`.
+- [ ] On workbook open, any cell whose call site references a `_DEBUG` variant causes FB to compile the debug delegate for the referenced `_src_` source.
+- [ ] The debug-mode transpiler emits a `Tracer.Begin / Set / Snapshot / Return` scaffold that captures every local and loop variable at: entry, end of each loop body iteration, and every `return`.
+- [ ] The `branch` column identifies which `if/else` arm executed at each snapshot row.
+- [ ] `=FB.LastTrace()` spills a 2D array: one header row, one row per snapshot, one column per distinct local + `iter`, `kind` (entry/iter/return), and `branch` columns.
+- [ ] For the scoring-loop example in the spec, the trace correctly shows the per-iteration values of `currentPlayer`, `jScore`, `jTurns`, `kScore`, `kTurns`, `s`, and the branch taken.
+- [ ] Non-debug UDFs have no tracer code and no measurable perf regression vs. before this feature.
+- [ ] Trace buffers are cleared at the start of each debug UDF invocation (no cross-call accumulation).
+
+## Out of Scope
+
+- **Real debugger attach** (VS / WinDbg). That's a separate, future escape hatch — Roslyn `EmitOptions` with portable PDBs makes it mechanically possible, but the UX is out of scope here.
+- **Tracing inside closures / lambdas** (e.g. inside `.Where(x => ...)`). MVP only traces the top-level statement list and its loops. Phase 2 can extend this.
+- **Step-through / breakpoints.** This is batch tracing, not interactive debugging.
+- **Rich value rendering** for complex wrappers. MVP renders `ExcelTable` / `ExcelArray` values as a short preview string (`"ExcelTable(7×3)"`); full inline expansion is out of scope.
+- **Multi-cell trace aggregation.** `FB.LastTrace()` is single-cell and returns the most recent trace. A `FB.Trace(cellRef)` variant can come later.
+- **Persistent trace history.** Buffers live in-process; closing Excel drops them.
+- **Tracing across nested FB calls** (a `_DEBUG` UDF that calls another `_DEBUG` UDF). MVP scopes the trace to the outer call only.
+


### PR DESCRIPTION
## Summary
- Adds `specs/0015-trace-debugging.md` — LINQPad-style trace mode for FB: per-cell Debug toggle, instrumented `_DEBUG` UDF variant, `=FB.LastTrace()` spill
- Adds `plans/0015-trace-debugging.md` — five PR-sized tasks (Tracer bridge → rewriter → compile/register → editor toggle → rehydration + AddinTests)

Parent issue: #298 (children: #299 #300 #301 #302 #303)

## Test plan
- [x] Docs-only PR — no code to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)