### PR TITLE
Add DebugInstrumentationRewriter (task 2 of #298)

### DIFF
--- a/formula-boss.Tests/DebugInstrumentationRewriterTests.cs
+++ b/formula-boss.Tests/DebugInstrumentationRewriterTests.cs
@@ -1,0 +1,147 @@
+using FormulaBoss.Transpilation;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Xunit;
+
+namespace FormulaBoss.Tests;
+
+public class DebugInstrumentationRewriterTests
+{
+    private static string Rewrite(string blockText, string name = "TEST", string callerAddr = "\"A1\"")
+    {
+        var block = (BlockSyntax)SyntaxFactory.ParseStatement(blockText);
+        var rewritten = DebugInstrumentationRewriter.Instrument(block, name, callerAddr);
+        return rewritten.NormalizeWhitespace().ToFullString();
+    }
+
+    [Fact]
+    public void Instrument_PrependsBeginAndEntrySnapshot()
+    {
+        var code = Rewrite("{ return 1; }");
+
+        Assert.Contains("Tracer.Begin(\"TEST\", \"A1\")", code);
+        Assert.Contains("Tracer.Snapshot(\"entry\", 0, null)", code);
+    }
+
+    [Fact]
+    public void Instrument_EmitsSetAfterLocalDeclaration()
+    {
+        var code = Rewrite("{ var x = 1; return x; }");
+
+        Assert.Contains("Tracer.Set(\"x\", x)", code);
+    }
+
+    [Fact]
+    public void Instrument_EmitsSetForEachVariableInMultiDeclaration()
+    {
+        var code = Rewrite("{ var x = 1; var y = 2; return x + y; }");
+
+        Assert.Contains("Tracer.Set(\"x\", x)", code);
+        Assert.Contains("Tracer.Set(\"y\", y)", code);
+    }
+
+    [Fact]
+    public void Instrument_EmitsSetAfterSimpleAssignment()
+    {
+        var code = Rewrite("{ var x = 1; x = 2; return x; }");
+
+        // One after declaration, one after assignment.
+        Assert.True(code.Split("Tracer.Set(\"x\", x)").Length - 1 >= 2);
+    }
+
+    [Fact]
+    public void Instrument_ForeachBindsLoopVariableAndSnapshotsAtEnd()
+    {
+        var code = Rewrite("{ foreach (var r in rows) { var a = r; } return 0; }");
+
+        Assert.Contains("Tracer.Set(\"r\", r)", code);
+        Assert.Contains("Tracer.Set(\"a\", a)", code);
+        Assert.Contains("Tracer.Snapshot(\"iter\", 1, null)", code);
+    }
+
+    [Fact]
+    public void Instrument_NestedForeachTracksDepth()
+    {
+        var code = Rewrite(
+            "{ foreach (var r in rows) { foreach (var c in cols) { var v = 1; } } return 0; }");
+
+        Assert.Contains("Tracer.Snapshot(\"iter\", 1, null)", code);
+        Assert.Contains("Tracer.Snapshot(\"iter\", 2, null)", code);
+    }
+
+    [Fact]
+    public void Instrument_IfElse_TagsBranchLabels()
+    {
+        var code = Rewrite(
+            "{ if (a > 0) { return 1; } else { return -1; } }");
+
+        // Branch label derived from first statement of the arm.
+        Assert.Contains("Tracer.Snapshot(\"return\", 0, \"return 1;\")", code);
+        Assert.Contains("Tracer.Snapshot(\"return\", 0, \"return -1;\")", code);
+    }
+
+    [Fact]
+    public void Instrument_IfWithoutElse_LabelsThenArm()
+    {
+        var code = Rewrite("{ if (x > 0) { return x; } return 0; }");
+
+        Assert.Contains("Tracer.Snapshot(\"return\", 0, \"return x;\")", code);
+        // The trailing return is outside the if — branch label is null.
+        Assert.Contains("Tracer.Snapshot(\"return\", 0, null)", code);
+    }
+
+    [Fact]
+    public void Instrument_ReturnInLoop_UsesLoopDepthAndCapturesValue()
+    {
+        var code = Rewrite("{ foreach (var r in rows) { return r; } return 0; }");
+
+        Assert.Contains("var __fb_ret = r", code);
+        Assert.Contains("Tracer.Return(__fb_ret)", code);
+        Assert.Contains("Tracer.Snapshot(\"return\", 1, null)", code);
+        Assert.Contains("return __fb_ret;", code);
+    }
+
+    [Fact]
+    public void Instrument_EarlyReturn_CapturesValueBeforeReturning()
+    {
+        var code = Rewrite("{ var x = 5; if (x > 0) return x; return 0; }");
+
+        Assert.Contains("var __fb_ret = x", code);
+        Assert.Contains("Tracer.Return(__fb_ret)", code);
+        Assert.Contains("return __fb_ret;", code);
+    }
+
+    [Fact]
+    public void Instrument_ForLoop_TracksDeclaredVariableAndSnapshots()
+    {
+        var code = Rewrite("{ for (var i = 0; i < 10; i++) { var v = i; } return 0; }");
+
+        Assert.Contains("Tracer.Set(\"i\", i)", code);
+        Assert.Contains("Tracer.Set(\"v\", v)", code);
+        Assert.Contains("Tracer.Snapshot(\"iter\", 1, null)", code);
+    }
+
+    [Fact]
+    public void Instrument_WhileLoop_SnapshotsAtEnd()
+    {
+        var code = Rewrite("{ var i = 0; while (i < 10) { i = i + 1; } return i; }");
+
+        Assert.Contains("Tracer.Snapshot(\"iter\", 1, null)", code);
+    }
+
+    [Fact]
+    public void Instrument_BranchLabelTruncatedToMaxLength()
+    {
+        var code = Rewrite(
+            "{ if (a) { var longVariableNameThatExceedsLimit = 1; return 1; } return 0; }");
+
+        // The label should appear truncated to 20 chars — the full decl statement should NOT appear
+        // in any Snapshot call.
+        Assert.DoesNotContain(
+            "Tracer.Snapshot(\"return\", 0, \"var longVariableNameThatExceedsLimit = 1;\"",
+            code);
+    }
+}

--- a/formula-boss/Transpilation/CodeEmitter.cs
+++ b/formula-boss/Transpilation/CodeEmitter.cs
@@ -3,6 +3,10 @@ using System.Text;
 
 using FormulaBoss.Compilation;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace FormulaBoss.Transpilation;
 
 /// <summary>
@@ -12,6 +16,7 @@ namespace FormulaBoss.Transpilation;
 public class CodeEmitter
 {
     public const string UdfPrefix = "__FB_";
+    public const string DebugSuffix = "_DEBUG";
 
     private static readonly HashSet<string> ReservedExcelNames = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -124,6 +129,63 @@ public class CodeEmitter
 
         var source = BuildSource(rewrittenDetection, methodName);
         return new TranspileResult(source, methodName, detection.RequiresObjectModel, originalExpression);
+    }
+
+    /// <summary>
+    ///     Emits a debug-instrumented variant of the UDF. The method name gets a
+    ///     <see cref="DebugSuffix" /> suffix and the user block is rewritten by
+    ///     <see cref="DebugInstrumentationRewriter" /> to fire <c>Tracer</c> calls.
+    /// </summary>
+    /// <param name="detection">Detection result from <see cref="InputDetector" />.</param>
+    /// <param name="originalExpression">The original user expression.</param>
+    /// <param name="preferredName">Optional preferred UDF name (suffix is appended).</param>
+    /// <param name="headersByParameter">Column header mapping per parameter (as for <see cref="Emit" />).</param>
+    /// <param name="callerAddressExpression">
+    ///     C# expression that resolves to the caller cell address string. Defaults to an empty
+    ///     literal; the compile/register path supplies the real expression.
+    /// </param>
+    public TranspileResult EmitDebug(
+        DetectionResult detection,
+        string originalExpression,
+        string? preferredName = null,
+        Dictionary<string, string[]>? headersByParameter = null,
+        string callerAddressExpression = "\"\"")
+    {
+        var baseName = GenerateMethodName(originalExpression, preferredName);
+        var methodName = baseName + DebugSuffix;
+
+        var rewrittenDetection = detection;
+        if (headersByParameter is { Count: > 0 })
+        {
+            rewrittenDetection = ApplyDotNotationRewrite(detection, headersByParameter);
+        }
+
+        var instrumentedDetection = InstrumentForDebug(rewrittenDetection, methodName, callerAddressExpression);
+        var source = BuildSource(instrumentedDetection, methodName);
+        return new TranspileResult(source, methodName, detection.RequiresObjectModel, originalExpression);
+    }
+
+    private static DetectionResult InstrumentForDebug(
+        DetectionResult detection,
+        string traceName,
+        string callerAddressExpression)
+    {
+        // Normalise to a statement block so the rewriter sees a BlockSyntax in every case.
+        var blockText = detection.IsStatementBlock
+            ? detection.NormalizedExpression
+            : $"{{ return {detection.NormalizedExpression}; }}";
+
+        if (SyntaxFactory.ParseStatement(blockText) is not BlockSyntax block)
+        {
+            return detection;
+        }
+
+        var instrumented = DebugInstrumentationRewriter.Instrument(block, traceName, callerAddressExpression);
+        return detection with
+        {
+            NormalizedExpression = instrumented.NormalizeWhitespace().ToFullString(),
+            IsStatementBlock = true
+        };
     }
 
     private static DetectionResult ApplyDotNotationRewrite(

--- a/formula-boss/Transpilation/DebugInstrumentationRewriter.cs
+++ b/formula-boss/Transpilation/DebugInstrumentationRewriter.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -39,7 +39,7 @@ public class DebugInstrumentationRewriter : CSharpSyntaxRewriter
     public static BlockSyntax Instrument(BlockSyntax block, string traceName, string callerAddressExpression)
     {
         var rewriter = new DebugInstrumentationRewriter();
-        var rewritten = (BlockSyntax)rewriter.Visit(block)!;
+        var rewritten = (BlockSyntax)rewriter.Visit(block);
 
         var begin = SyntaxFactory.ParseStatement(
             $"{TracerType}.Begin({Literal(traceName)}, {callerAddressExpression});");
@@ -51,7 +51,7 @@ public class DebugInstrumentationRewriter : CSharpSyntaxRewriter
         return rewritten.WithStatements(SyntaxFactory.List(statements));
     }
 
-    public override SyntaxNode? VisitBlock(BlockSyntax node)
+    public override SyntaxNode VisitBlock(BlockSyntax node)
     {
         var newStatements = new List<StatementSyntax>();
         foreach (var stmt in node.Statements)
@@ -83,10 +83,10 @@ public class DebugInstrumentationRewriter : CSharpSyntaxRewriter
         return node.WithStatements(SyntaxFactory.List(newStatements));
     }
 
-    public override SyntaxNode? VisitForEachStatement(ForEachStatementSyntax node)
+    public override SyntaxNode VisitForEachStatement(ForEachStatementSyntax node)
     {
         _loopDepth++;
-        var body = EnsureBlock((StatementSyntax)Visit(node.Statement)!);
+        var body = EnsureBlock((StatementSyntax)Visit(node.Statement));
         var statements = new List<StatementSyntax> { MakeSet(node.Identifier.Text) };
         statements.AddRange(body.Statements);
         statements.Add(MakeSnapshot("iter"));
@@ -95,10 +95,10 @@ public class DebugInstrumentationRewriter : CSharpSyntaxRewriter
         return node.WithStatement(newBody);
     }
 
-    public override SyntaxNode? VisitForStatement(ForStatementSyntax node)
+    public override SyntaxNode VisitForStatement(ForStatementSyntax node)
     {
         _loopDepth++;
-        var body = EnsureBlock((StatementSyntax)Visit(node.Statement)!);
+        var body = EnsureBlock((StatementSyntax)Visit(node.Statement));
         var statements = new List<StatementSyntax>();
         if (node.Declaration != null)
         {
@@ -115,28 +115,28 @@ public class DebugInstrumentationRewriter : CSharpSyntaxRewriter
         return node.WithStatement(newBody);
     }
 
-    public override SyntaxNode? VisitWhileStatement(WhileStatementSyntax node)
+    public override SyntaxNode VisitWhileStatement(WhileStatementSyntax node)
     {
         _loopDepth++;
-        var body = EnsureBlock((StatementSyntax)Visit(node.Statement)!);
+        var body = EnsureBlock((StatementSyntax)Visit(node.Statement));
         var statements = new List<StatementSyntax>(body.Statements) { MakeSnapshot("iter") };
         var newBody = body.WithStatements(SyntaxFactory.List(statements));
         _loopDepth--;
         return node.WithStatement(newBody);
     }
 
-    public override SyntaxNode? VisitIfStatement(IfStatementSyntax node)
+    public override SyntaxNode VisitIfStatement(IfStatementSyntax node)
     {
         var savedBranch = _branchLabel;
 
         _branchLabel = MakeBranchLabel(node.Statement);
-        var visitedThen = (StatementSyntax)Visit(node.Statement)!;
+        var visitedThen = (StatementSyntax)Visit(node.Statement);
 
         ElseClauseSyntax? visitedElse = null;
         if (node.Else != null)
         {
             _branchLabel = MakeBranchLabel(node.Else.Statement);
-            var visitedElseStmt = (StatementSyntax)Visit(node.Else.Statement)!;
+            var visitedElseStmt = (StatementSyntax)Visit(node.Else.Statement);
             visitedElse = node.Else.WithStatement(visitedElseStmt);
         }
 
@@ -146,7 +146,7 @@ public class DebugInstrumentationRewriter : CSharpSyntaxRewriter
             : node.WithStatement(visitedThen);
     }
 
-    public override SyntaxNode? VisitReturnStatement(ReturnStatementSyntax node)
+    public override SyntaxNode VisitReturnStatement(ReturnStatementSyntax node)
     {
         if (node.Expression == null)
         {
@@ -177,7 +177,7 @@ public class DebugInstrumentationRewriter : CSharpSyntaxRewriter
 
     private static string MakeBranchLabel(StatementSyntax stmt)
     {
-        StatementSyntax? first = stmt;
+        var first = stmt;
         if (stmt is BlockSyntax block)
         {
             first = block.Statements.FirstOrDefault();

--- a/formula-boss/Transpilation/DebugInstrumentationRewriter.cs
+++ b/formula-boss/Transpilation/DebugInstrumentationRewriter.cs
@@ -1,0 +1,202 @@
+using System.Text.RegularExpressions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace FormulaBoss.Transpilation;
+
+/// <summary>
+///     Rewrites a user statement block to emit <see cref="FormulaBoss.Runtime.Tracer" /> calls for
+///     debug mode. Inserts <c>Tracer.Begin</c> + an entry snapshot at the top, <c>Tracer.Set</c>
+///     after each local declaration / assignment, <c>Tracer.Snapshot("iter", depth, branch)</c> at
+///     the end of each loop body, and rewrites <c>return</c> statements to capture the returned
+///     value, fire <c>Tracer.Return</c>, and snapshot before returning.
+///     Loop depth is tracked via a visit counter. Branch labels are derived from the first
+///     statement of each if/else arm (trimmed and truncated to <see cref="BranchLabelMaxLength" />).
+/// </summary>
+public class DebugInstrumentationRewriter : CSharpSyntaxRewriter
+{
+    private const string TracerType = "FormulaBoss.Runtime.Tracer";
+    private const string ReturnTempName = "__fb_ret";
+    private const int BranchLabelMaxLength = 20;
+
+    private static readonly Regex WhitespaceRun = new(@"\s+", RegexOptions.Compiled);
+
+    private string? _branchLabel;
+    private int _loopDepth;
+
+    /// <summary>
+    ///     Instrument a block. Prepends <c>Tracer.Begin(name, callerAddr)</c> + entry snapshot,
+    ///     then recursively injects Set/Snapshot/Return calls inside the block.
+    /// </summary>
+    /// <param name="block">The user's statement block.</param>
+    /// <param name="traceName">Name recorded by <c>Tracer.Begin</c> (usually the UDF method name).</param>
+    /// <param name="callerAddressExpression">
+    ///     A C# expression (already formatted) that evaluates to the caller cell address string.
+    ///     Use <c>"\"\""</c> as a placeholder when the address is not yet wired.
+    /// </param>
+    public static BlockSyntax Instrument(BlockSyntax block, string traceName, string callerAddressExpression)
+    {
+        var rewriter = new DebugInstrumentationRewriter();
+        var rewritten = (BlockSyntax)rewriter.Visit(block)!;
+
+        var begin = SyntaxFactory.ParseStatement(
+            $"{TracerType}.Begin({Literal(traceName)}, {callerAddressExpression});");
+        var entry = SyntaxFactory.ParseStatement(
+            $"{TracerType}.Snapshot(\"entry\", 0, null);");
+
+        var statements = new List<StatementSyntax> { begin, entry };
+        statements.AddRange(rewritten.Statements);
+        return rewritten.WithStatements(SyntaxFactory.List(statements));
+    }
+
+    public override SyntaxNode? VisitBlock(BlockSyntax node)
+    {
+        var newStatements = new List<StatementSyntax>();
+        foreach (var stmt in node.Statements)
+        {
+            if (Visit(stmt) is not StatementSyntax visited)
+            {
+                continue;
+            }
+
+            newStatements.Add(visited);
+
+            // Insert Tracer.Set calls for newly-assigned locals.
+            switch (stmt)
+            {
+                case LocalDeclarationStatementSyntax decl:
+                    foreach (var v in decl.Declaration.Variables)
+                    {
+                        newStatements.Add(MakeSet(v.Identifier.Text));
+                    }
+
+                    break;
+                case ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax assign }
+                    when assign.Left is IdentifierNameSyntax id:
+                    newStatements.Add(MakeSet(id.Identifier.Text));
+                    break;
+            }
+        }
+
+        return node.WithStatements(SyntaxFactory.List(newStatements));
+    }
+
+    public override SyntaxNode? VisitForEachStatement(ForEachStatementSyntax node)
+    {
+        _loopDepth++;
+        var body = EnsureBlock((StatementSyntax)Visit(node.Statement)!);
+        var statements = new List<StatementSyntax> { MakeSet(node.Identifier.Text) };
+        statements.AddRange(body.Statements);
+        statements.Add(MakeSnapshot("iter"));
+        var newBody = body.WithStatements(SyntaxFactory.List(statements));
+        _loopDepth--;
+        return node.WithStatement(newBody);
+    }
+
+    public override SyntaxNode? VisitForStatement(ForStatementSyntax node)
+    {
+        _loopDepth++;
+        var body = EnsureBlock((StatementSyntax)Visit(node.Statement)!);
+        var statements = new List<StatementSyntax>();
+        if (node.Declaration != null)
+        {
+            foreach (var v in node.Declaration.Variables)
+            {
+                statements.Add(MakeSet(v.Identifier.Text));
+            }
+        }
+
+        statements.AddRange(body.Statements);
+        statements.Add(MakeSnapshot("iter"));
+        var newBody = body.WithStatements(SyntaxFactory.List(statements));
+        _loopDepth--;
+        return node.WithStatement(newBody);
+    }
+
+    public override SyntaxNode? VisitWhileStatement(WhileStatementSyntax node)
+    {
+        _loopDepth++;
+        var body = EnsureBlock((StatementSyntax)Visit(node.Statement)!);
+        var statements = new List<StatementSyntax>(body.Statements) { MakeSnapshot("iter") };
+        var newBody = body.WithStatements(SyntaxFactory.List(statements));
+        _loopDepth--;
+        return node.WithStatement(newBody);
+    }
+
+    public override SyntaxNode? VisitIfStatement(IfStatementSyntax node)
+    {
+        var savedBranch = _branchLabel;
+
+        _branchLabel = MakeBranchLabel(node.Statement);
+        var visitedThen = (StatementSyntax)Visit(node.Statement)!;
+
+        ElseClauseSyntax? visitedElse = null;
+        if (node.Else != null)
+        {
+            _branchLabel = MakeBranchLabel(node.Else.Statement);
+            var visitedElseStmt = (StatementSyntax)Visit(node.Else.Statement)!;
+            visitedElse = node.Else.WithStatement(visitedElseStmt);
+        }
+
+        _branchLabel = savedBranch;
+        return visitedElse != null
+            ? node.WithStatement(visitedThen).WithElse(visitedElse)
+            : node.WithStatement(visitedThen);
+    }
+
+    public override SyntaxNode? VisitReturnStatement(ReturnStatementSyntax node)
+    {
+        if (node.Expression == null)
+        {
+            return node;
+        }
+
+        var tempDecl = SyntaxFactory.ParseStatement(
+            $"var {ReturnTempName} = {node.Expression.ToFullString()};");
+        var returnCall = SyntaxFactory.ParseStatement(
+            $"{TracerType}.Return({ReturnTempName});");
+        var snapshot = MakeSnapshot("return");
+        var ret = SyntaxFactory.ParseStatement($"return {ReturnTempName};");
+
+        return SyntaxFactory.Block(tempDecl, returnCall, snapshot, ret);
+    }
+
+    private StatementSyntax MakeSet(string name)
+        => SyntaxFactory.ParseStatement($"{TracerType}.Set({Literal(name)}, {name});");
+
+    private StatementSyntax MakeSnapshot(string kind)
+        => SyntaxFactory.ParseStatement(
+            $"{TracerType}.Snapshot({Literal(kind)}, {_loopDepth}, {BranchArg()});");
+
+    private string BranchArg() => _branchLabel == null ? "null" : Literal(_branchLabel);
+
+    private static BlockSyntax EnsureBlock(StatementSyntax stmt)
+        => stmt is BlockSyntax b ? b : SyntaxFactory.Block(stmt);
+
+    private static string MakeBranchLabel(StatementSyntax stmt)
+    {
+        StatementSyntax? first = stmt;
+        if (stmt is BlockSyntax block)
+        {
+            first = block.Statements.FirstOrDefault();
+        }
+
+        if (first == null)
+        {
+            return string.Empty;
+        }
+
+        var text = WhitespaceRun.Replace(first.ToString().Trim(), " ");
+        if (text.Length > BranchLabelMaxLength)
+        {
+            text = text[..BranchLabelMaxLength];
+        }
+
+        return text;
+    }
+
+    private static string Literal(string s)
+        => "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+}

--- a/formula-boss/Transpilation/TranspileResult.cs
+++ b/formula-boss/Transpilation/TranspileResult.cs
@@ -11,4 +11,12 @@ public record TranspileResult(
     string SourceCode,
     string MethodName,
     bool RequiresObjectModel,
-    string OriginalExpression);
+    string OriginalExpression)
+{
+    /// <summary>
+    ///     Optional parallel debug-instrumented source code and method name. Populated by
+    ///     <see cref="CodeEmitter.EmitDebug" /> when a debug variant is requested alongside the
+    ///     normal emit.
+    /// </summary>
+    public TranspileResult? DebugVariant { get; init; }
+}


### PR DESCRIPTION
## Summary

- `DebugInstrumentationRewriter` — a `CSharpSyntaxRewriter` that instruments a user block: prepends `Tracer.Begin` + entry snapshot, injects `Tracer.Set` after local declarations / assignments, wraps loop bodies with `Tracer.Set` for loop variables + a trailing `Tracer.Snapshot("iter", depth, branch)`, and rewrites `return` statements to capture the returned value before firing `Tracer.Return` + a `"return"` snapshot.
- Branch labels are derived from the first statement of each if/else arm (trimmed, 20-char cap); loop depth is tracked via a visit counter.
- `CodeEmitter.EmitDebug` runs the rewriter and emits the instrumented block under a `__FB_<NAME>_DEBUG` method (new constant `CodeEmitter.DebugSuffix = "_DEBUG"`).
- `TranspileResult` gains an optional `DebugVariant` property for the compile/register pipeline in task 3.

No compile/register wiring yet — tests assert on the emitted source string (loose `Contains` assertions per the plan).

Closes #300

## Test plan

- [x] `dotnet test formula-boss/formula-boss.slnx` — 631 tests pass (13 new in `DebugInstrumentationRewriterTests`).
- [x] Task 3 will exercise the full compile path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)