### PR TITLE
Add debug compile/register path and FB.LastTrace UDF

### DIFF
--- a/formula-boss.Runtime/Tracer.cs
+++ b/formula-boss.Runtime/Tracer.cs
@@ -132,6 +132,13 @@ public sealed class TraceBuffer
 
     internal void Set(string name, object? value)
     {
+        // Unwrap ExcelValue wrappers to their underlying primitive so that
+        // ToObjectArray() produces values Excel can display (not #VALUE!).
+        if (value is ExcelValue ev)
+        {
+            value = ev.RawValue;
+        }
+
         lock (_sync)
         {
             _liveState[name] = value;

--- a/formula-boss.Tests/DebugInstrumentationRewriterTests.cs
+++ b/formula-boss.Tests/DebugInstrumentationRewriterTests.cs
@@ -133,6 +133,31 @@ public class DebugInstrumentationRewriterTests
     }
 
     [Fact]
+    public void Instrument_EmitsSetAfterPostfixIncrement()
+    {
+        var code = Rewrite("{ var x = 0; x++; return x; }");
+
+        // One after declaration, one after x++
+        Assert.True(code.Split("Tracer.Set(\"x\", x)").Length - 1 >= 2);
+    }
+
+    [Fact]
+    public void Instrument_EmitsSetAfterPostfixDecrement()
+    {
+        var code = Rewrite("{ var x = 5; x--; return x; }");
+
+        Assert.True(code.Split("Tracer.Set(\"x\", x)").Length - 1 >= 2);
+    }
+
+    [Fact]
+    public void Instrument_EmitsSetAfterPrefixIncrement()
+    {
+        var code = Rewrite("{ var x = 0; ++x; return x; }");
+
+        Assert.True(code.Split("Tracer.Set(\"x\", x)").Length - 1 >= 2);
+    }
+
+    [Fact]
     public void Instrument_BranchLabelTruncatedToMaxLength()
     {
         var code = Rewrite(

--- a/formula-boss.Tests/InterceptionTests.cs
+++ b/formula-boss.Tests/InterceptionTests.cs
@@ -213,7 +213,7 @@ public class InterceptionTests
         Assert.True(result2.Success);
         Assert.Equal($"{CodeEmitter.UdfPrefix}FIRSTUDF", result1.UdfName);
         Assert.Equal($"{CodeEmitter.UdfPrefix}SECONDUDF", result2.UdfName);
-        Assert.Equal(2, compiler.CompileCount); // Should compile twice
+        Assert.Equal(4, compiler.CompileCount); // 2 normal + 2 debug variants
     }
 
     [Fact]
@@ -253,7 +253,7 @@ public class InterceptionTests
         Assert.True(result1.Success);
         Assert.True(result2.Success);
         Assert.Equal(result1.UdfName, result2.UdfName);
-        Assert.Equal(1, compiler.CompileCount); // Should only compile once
+        Assert.Equal(2, compiler.CompileCount); // 1 normal + 1 debug variant (second call hits cache)
     }
 
     [Fact]

--- a/formula-boss.Tests/TracerTests.cs
+++ b/formula-boss.Tests/TracerTests.cs
@@ -205,4 +205,29 @@ public class TracerTests : IDisposable
         Tracer.TruncateWarn();
         Assert.Null(Tracer.LastBuffer);
     }
+
+    [Fact]
+    public void Set_UnwrapsExcelScalar_ToRawValue()
+    {
+        Tracer.Begin("foo", "A1");
+        var scalar = ExcelValue.Wrap(42.0);
+        Tracer.Set("x", scalar);
+        Tracer.Snapshot("iter", 0, null);
+
+        var arr = Tracer.LastBuffer!.ToObjectArray();
+        // Column: kind, depth, branch, x
+        Assert.Equal(42.0, arr[1, 3]);
+    }
+
+    [Fact]
+    public void Set_UnwrapsExcelScalar_StringValue()
+    {
+        Tracer.Begin("foo", "A1");
+        var scalar = ExcelValue.Wrap("hello");
+        Tracer.Set("s", scalar);
+        Tracer.Snapshot("iter", 0, null);
+
+        var arr = Tracer.LastBuffer!.ToObjectArray();
+        Assert.Equal("hello", arr[1, 3]);
+    }
 }

--- a/formula-boss/AddIn.cs
+++ b/formula-boss/AddIn.cs
@@ -194,9 +194,26 @@ public sealed class AddIn : IExcelAddIn, IDisposable
             // Initialize result conversion delegate — delegates to shared ResultConverter.Convert()
             RuntimeHelpers.ToResultDelegate = result => ResultConverter.Convert(result);
 
-            // Reset the debug-mode trace buffer. Subsequent tasks in #298 will add delegate
-            // initialisation here as the rewriter and compile path are wired up.
+            // Reset the debug-mode trace buffer and wire up the caller-address delegate
+            // so debug-instrumented UDFs can pass the calling cell address to Tracer.Begin.
             Tracer.Reset();
+            RuntimeHelpers.GetCallerAddressDelegate = () =>
+            {
+                try
+                {
+                    var caller = XlCall.Excel(XlCall.xlfCaller);
+                    if (caller?.GetType().Name == "ExcelReference")
+                    {
+                        return (string)XlCall.Excel(XlCall.xlfReftext, caller, true);
+                    }
+
+                    return "";
+                }
+                catch
+                {
+                    return "";
+                }
+            };
 
             // Defer event hookup until Excel is fully initialized
             // ExcelAsyncUtil.QueueAsMacro ensures we run after AutoOpen completes

--- a/formula-boss/Interception/FormulaPipeline.cs
+++ b/formula-boss/Interception/FormulaPipeline.cs
@@ -96,17 +96,15 @@ public class FormulaPipeline
 
         // Step 2: Emit code
         var emitter = new CodeEmitter();
+        var preferredName = context?.PreferredUdfName;
+        if (preferredName != null)
+        {
+            preferredName = GetUniqueUdfName(preferredName, expression);
+        }
+
         TranspileResult transpileResult;
         try
         {
-            var preferredName = context?.PreferredUdfName;
-
-            // If we have a preferred name, check if it's already registered with a different expression
-            if (preferredName != null)
-            {
-                preferredName = GetUniqueUdfName(preferredName, expression);
-            }
-
             transpileResult = emitter.Emit(emitDetection, expression, preferredName);
         }
         catch (Exception ex)
@@ -132,6 +130,37 @@ public class FormulaPipeline
             }
 
             return new PipelineResult(false, null, $"Compile error: {errorMsg}");
+        }
+
+        // Step 3b: Emit and compile the debug-instrumented variant alongside the normal one.
+        // The caller address expression invokes the delegate bridge so the generated code
+        // does not need to reference ExcelDNA's XlCall directly.
+        try
+        {
+            var callerAddrExpr = "FormulaBoss.RuntimeHelpers.GetCallerAddressDelegate?.Invoke() ?? \"\"";
+            var debugResult = emitter.EmitDebug(
+                emitDetection, expression, preferredName,
+                headersByParameter: null, callerAddrExpr);
+
+            Debug.WriteLine("=== Generated DEBUG UDF Source Code ===");
+            Debug.WriteLine(debugResult.SourceCode);
+            Debug.WriteLine("=== End Generated DEBUG Code ===");
+
+            var debugErrors = _compiler.CompileAndRegister(
+                debugResult.SourceCode, debugResult.RequiresObjectModel);
+
+            if (debugErrors.Count > 0)
+            {
+                Debug.WriteLine($"Debug variant compile failed: {string.Join("; ", debugErrors)}");
+            }
+            else
+            {
+                transpileResult = transpileResult with { DebugVariant = debugResult };
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Debug variant emit failed: {ex.Message}");
         }
 
         // Track which expression this UDF name was created from

--- a/formula-boss/LastTraceUdf.cs
+++ b/formula-boss/LastTraceUdf.cs
@@ -1,0 +1,26 @@
+using ExcelDna.Integration;
+
+using FormulaBoss.Runtime;
+
+namespace FormulaBoss;
+
+/// <summary>
+///     Hosts the <c>FB.LastTrace()</c> UDF that spills the most recent debug trace buffer
+///     as a 2D array with a header row. Returns an error string when no trace has been captured.
+/// </summary>
+public static class LastTraceUdf
+{
+    [ExcelFunction(
+        Name = "FB.LastTrace",
+        Description = "Returns the most recent debug trace buffer as a spilled table.")]
+    public static object LastTrace()
+    {
+        var buffer = Tracer.LastBuffer;
+        if (buffer == null)
+        {
+            return "#N/A \u2014 no trace captured";
+        }
+
+        return buffer.ToObjectArray();
+    }
+}

--- a/formula-boss/RuntimeHelpers.cs
+++ b/formula-boss/RuntimeHelpers.cs
@@ -101,6 +101,14 @@ public static class RuntimeHelpers
     public static Func<object, object>? ToResultDelegate { get; set; }
 
     /// <summary>
+    ///     Delegate that returns the calling cell's address as a string (e.g. "[Book1]Sheet1!$A$1").
+    ///     Used by debug-instrumented UDFs to pass the caller address to <c>Tracer.Begin</c>.
+    ///     Initialized by <c>AddIn.AutoOpen</c> with a lambda that calls
+    ///     <c>XlCall.Excel(xlfCaller)</c> then <c>xlfReftext</c>.
+    /// </summary>
+    public static Func<string>? GetCallerAddressDelegate { get; set; }
+
+    /// <summary>
     ///     Normalizes a result for return to Excel.
     ///     Handles arrays, enumerables, nulls, and scalars.
     /// </summary>

--- a/formula-boss/Transpilation/DebugInstrumentationRewriter.cs
+++ b/formula-boss/Transpilation/DebugInstrumentationRewriter.cs
@@ -77,6 +77,18 @@ public class DebugInstrumentationRewriter : CSharpSyntaxRewriter
                     when assign.Left is IdentifierNameSyntax id:
                     newStatements.Add(MakeSet(id.Identifier.Text));
                     break;
+                case ExpressionStatementSyntax { Expression: PostfixUnaryExpressionSyntax postfix }
+                    when postfix.Operand is IdentifierNameSyntax postfixId &&
+                         (postfix.IsKind(SyntaxKind.PostIncrementExpression) ||
+                          postfix.IsKind(SyntaxKind.PostDecrementExpression)):
+                    newStatements.Add(MakeSet(postfixId.Identifier.Text));
+                    break;
+                case ExpressionStatementSyntax { Expression: PrefixUnaryExpressionSyntax prefix }
+                    when prefix.Operand is IdentifierNameSyntax prefixId &&
+                         (prefix.IsKind(SyntaxKind.PreIncrementExpression) ||
+                          prefix.IsKind(SyntaxKind.PreDecrementExpression)):
+                    newStatements.Add(MakeSet(prefixId.Identifier.Text));
+                    break;
             }
         }
 


### PR DESCRIPTION
Closes #301

## Summary
- **Caller-address delegate bridge**: `RuntimeHelpers.GetCallerAddressDelegate` resolves the calling cell's address via `xlfCaller` + `xlfReftext`, initialized in `AddIn.AutoOpen`
- **Debug variant compile path**: `FormulaPipeline.Process` now emits and compiles a `_DEBUG` variant alongside every normal UDF, using `CodeEmitter.EmitDebug` with the caller-address expression
- **`FB.LastTrace()` UDF**: Static `[ExcelFunction]` that returns `Tracer.LastBuffer?.ToObjectArray()` or an error string — auto-discovered by ExcelDNA at startup

At this point you can manually rewrite a cell's formula in the Excel formula bar to `__FB_FOO_DEBUG(...)` and see `=FB.LastTrace()` spill a trace table.

## Test plan
- [x] All 553 unit tests pass (updated compile-count assertions for the new debug path)
- [x] All 35 integration tests pass
- [x] All 43 AddinTests pass (add-in loads and existing formulas work)
- [x] Manual smoke test: enter a formula, manually edit call site to `_DEBUG` variant, verify `=FB.LastTrace()` spills
- [x] Manual perf sanity check: compile time with vs. without debug pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)