### PR TITLE
Auto-wrap plain backtick formulas in LET with _src_ binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Instead:
 - Better yet, make your expression a LET argument, so that Formula Boss will give it a nice name instead of a hash.
 - Either way, your formula is fully editable — press _Ctrl+Shift+`_ on any Formula Boss cell to reopen the editor.
 
-🚨 Warning: The Formula Boss is forgetful. It won't remember your functions next time you open Excel. You can recreate them by opening and saving the workbook, but if you haven't saved, they're gone!
+🚨 Warning: The Formula Boss is forgetful. It won't automatically remember your functions next time you open Excel, but it WILL recreate them if you still have Formula Boss active and you haven't removed the source code from your LET.
 
 🫣 **"But I don't know C#!"**
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Formula Boss detects the expression, turns it into a User Defined Function (UDF)
 
 Instead:
 - Use the visual editor by pressing _Ctrl+Shift+`_.
-- Better yet, make your expression a LET argument, so that Formula Boss will give it a nice name.
-- Outside of a LET, your function won't be editable - inside a LET, you can use the visual editor to edit your function as much as you like.
+- Better yet, make your expression a LET argument, so that Formula Boss will give it a nice name instead of a hash.
+- Either way, your formula is fully editable — press _Ctrl+Shift+`_ on any Formula Boss cell to reopen the editor.
 
-🚨 Warning: The Formula Boss is forgetful. It won't remember your functions next time you open Excel. If you used a LET function, you can recreate them, otherwise they're gone for good!
+🚨 Warning: The Formula Boss is forgetful. It won't remember your functions next time you open Excel. You can recreate them by opening and saving the workbook, but if you haven't saved, they're gone!
 
 🫣 **"But I don't know C#!"**
 

--- a/formula-boss.AddinTests/PipelineTests.cs
+++ b/formula-boss.AddinTests/PipelineTests.cs
@@ -1469,4 +1469,113 @@ public class PipelineTests
             TestUtilities.CleanupWorksheet(ws);
         }
     }
+
+    [Fact]
+    public void PlainBacktick_ProducesLetWithSrcBinding()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            TestUtilities.SetCellValue(ws, "A1", 10.0);
+            TestUtilities.SetCellValue(ws, "A2", 20.0);
+            TestUtilities.SetCellValue(ws, "A3", 30.0);
+
+            TestUtilities.EnterBacktickFormula(ws, "B1", "=`A1:A3.Sum()`");
+
+            var result = TestUtilities.WaitForResult(ws, "B1", _output);
+
+            var formula = TestUtilities.GetCellFormula(ws, "B1");
+            _output.WriteLine($"B1 formula: {formula}");
+            _output.WriteLine($"B1 value: {result}");
+
+            Assert.NotNull(result);
+            Assert.Equal(60.0, Convert.ToDouble(result));
+
+            // Formula should be a LET with _src_ binding
+            Assert.NotNull(formula);
+            Assert.StartsWith("=LET(", formula);
+            Assert.Contains("_src_", formula);
+            Assert.Contains("\"A1:A3.Sum()\"", formula);
+        }
+        finally
+        {
+            TestUtilities.CleanupWorksheet(ws);
+        }
+    }
+
+    [Fact]
+    public void PlainBacktick_ReEdit_ProducesCorrectResult()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            TestUtilities.SetCellValue(ws, "A1", 10.0);
+            TestUtilities.SetCellValue(ws, "A2", 20.0);
+            TestUtilities.SetCellValue(ws, "A3", 30.0);
+
+            // Step 1: Enter initial backtick formula
+            TestUtilities.EnterBacktickFormula(ws, "B1", "=`A1:A3.Sum()`");
+
+            var result1 = TestUtilities.WaitForResult(ws, "B1", _output);
+            Assert.NotNull(result1);
+            Assert.Equal(60.0, Convert.ToDouble(result1));
+
+            var formula1 = TestUtilities.GetCellFormula(ws, "B1");
+            _output.WriteLine($"Step 1 - B1 formula: {formula1}");
+
+            // Verify the LET structure with _src_ binding
+            Assert.NotNull(formula1);
+            Assert.StartsWith("=LET(", formula1);
+            Assert.Contains("_src_", formula1);
+
+            // Step 2: Re-enter with a different expression (simulating re-edit)
+            TestUtilities.EnterBacktickFormula(ws, "B1", "=`A1:A3.Count()`");
+
+            var result2 = TestUtilities.WaitForResult(ws, "B1", _output);
+
+            _output.WriteLine($"Step 2 - B1 formula: {TestUtilities.GetCellFormula(ws, "B1")}");
+            _output.WriteLine($"Step 2 - B1 value: {result2}");
+
+            Assert.NotNull(result2);
+            Assert.Equal(3.0, Convert.ToDouble(result2));
+        }
+        finally
+        {
+            TestUtilities.CleanupWorksheet(ws);
+        }
+    }
+
+    [Fact]
+    public void PlainBacktick_MultipleExpressions_ProducesLetWithMultipleSrcBindings()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            TestUtilities.SetCellValue(ws, "A1", 10.0);
+            TestUtilities.SetCellValue(ws, "A2", 20.0);
+            TestUtilities.SetCellValue(ws, "B1", 3.0);
+            TestUtilities.SetCellValue(ws, "B2", 7.0);
+
+            TestUtilities.EnterBacktickFormula(ws, "C1", "=`A1:A2.Sum()` + `B1:B2.Sum()`");
+
+            var result = TestUtilities.WaitForResult(ws, "C1", _output);
+
+            var formula = TestUtilities.GetCellFormula(ws, "C1");
+            _output.WriteLine($"C1 formula: {formula}");
+            _output.WriteLine($"C1 value: {result}");
+
+            Assert.NotNull(result);
+            Assert.Equal(40.0, Convert.ToDouble(result));
+
+            // Formula should be a LET with _src_ bindings for both expressions
+            Assert.NotNull(formula);
+            Assert.StartsWith("=LET(", formula);
+            Assert.Contains("\"A1:A2.Sum()\"", formula);
+            Assert.Contains("\"B1:B2.Sum()\"", formula);
+        }
+        finally
+        {
+            TestUtilities.CleanupWorksheet(ws);
+        }
+    }
 }

--- a/formula-boss.Tests/LetFormulaReconstructorTests.cs
+++ b/formula-boss.Tests/LetFormulaReconstructorTests.cs
@@ -562,4 +562,62 @@ public class LetFormulaReconstructorTests
     }
 
     #endregion
+
+    #region Auto-Wrapped Plain Backtick Reconstruction
+
+    [Fact]
+    public void TryReconstruct_AutoWrappedSingleBacktick_ReconstructsPlainFormula()
+    {
+        // Auto-wrapped plain backtick: =LET(_src_AB12CD34, "A1:A3.Sum()", __FB_AB12CD34(A1:A3))
+        var processed = @"=LET(_src_AB12CD34, ""A1:A3.Sum()"", __FB_AB12CD34(A1:A3))";
+
+        var result = LetFormulaReconstructor.TryReconstruct(processed, out var editable);
+
+        Assert.True(result);
+        Assert.NotNull(editable);
+        // Should reconstruct to plain backtick formula (no LET wrapper)
+        Assert.StartsWith("'=", editable);
+        Assert.Contains("`A1:A3.Sum()`", editable);
+        Assert.DoesNotContain("LET", editable);
+        Assert.DoesNotContain("_src_", editable);
+    }
+
+    [Fact]
+    public void TryReconstruct_AutoWrappedMultipleBackticks_ReconstructsPlainFormula()
+    {
+        // Auto-wrapped multiple backtick expressions:
+        // =LET(_src_XXXX, "A1:A2.Sum()", _src_YYYY, "B1:B2.Sum()", __FB_XXXX(A1:A2) + __FB_YYYY(B1:B2))
+        var processed = @"=LET(_src_XXXX, ""A1:A2.Sum()"", _src_YYYY, ""B1:B2.Sum()"", __FB_XXXX(A1:A2) + __FB_YYYY(B1:B2))";
+
+        var result = LetFormulaReconstructor.TryReconstruct(processed, out var editable);
+
+        Assert.True(result);
+        Assert.NotNull(editable);
+        Assert.Contains("`A1:A2.Sum()`", editable);
+        Assert.Contains("`B1:B2.Sum()`", editable);
+        Assert.DoesNotContain("LET", editable);
+        Assert.DoesNotContain("_src_", editable);
+        Assert.DoesNotContain("__FB_", editable);
+    }
+
+    [Fact]
+    public void TryReconstruct_AutoWrappedWithEscapedQuotes_UnescapesCorrectly()
+    {
+        var processed = @"=LET(_src_AB12CD34, ""data.where(v => v == """"test"""")"", __FB_AB12CD34(A1:A10))";
+
+        var result = LetFormulaReconstructor.TryReconstruct(processed, out var editable);
+
+        Assert.True(result);
+        Assert.NotNull(editable);
+        Assert.Contains(@"`data.where(v => v == ""test"")`", editable);
+    }
+
+    [Fact]
+    public void IsProcessedFormulaBossLet_ReturnsTrue_ForAutoWrappedFormula()
+    {
+        var formula = @"=LET(_src_AB12CD34, ""A1:A3.Sum()"", __FB_AB12CD34(A1:A3))";
+        Assert.True(LetFormulaReconstructor.IsProcessedFormulaBossLet(formula));
+    }
+
+    #endregion
 }

--- a/formula-boss/Interception/FormulaInterceptor.cs
+++ b/formula-boss/Interception/FormulaInterceptor.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 
 using ExcelDna.Integration;
 
+using FormulaBoss.Transpilation;
 using FormulaBoss.UI;
 
 using Taglo.Excel.Common;
@@ -337,6 +338,8 @@ public class FormulaInterceptor : IDisposable
         }
 
         var replacements = new Dictionary<string, string>();
+        // Track each processed expression for _src_ binding generation (preserves order)
+        var processedExpressions = new List<(string DslExpression, string UdfName, string UdfCall)>();
         var errors = new List<string>();
 
         foreach (var expr in expressions)
@@ -353,6 +356,7 @@ public class FormulaInterceptor : IDisposable
                     : "";
                 var udfCall = $"{result.UdfName}({paramStr})";
                 replacements[expr.Expression] = udfCall;
+                processedExpressions.Add((expr.Expression, result.UdfName, udfCall));
                 Debug.WriteLine($"UDF generated: {udfCall}");
             }
             else
@@ -368,10 +372,47 @@ public class FormulaInterceptor : IDisposable
             return;
         }
 
-        var newFormula = BacktickExtractor.RewriteFormula(originalFormula, replacements);
+        // Rewrite backtick expressions to UDF calls
+        var rewrittenFormula = BacktickExtractor.RewriteFormula(originalFormula, replacements);
+
+        // Wrap in LET with _src_ bindings so the formula is rehydration-capable and editor-reopenable
+        var newFormula = WrapInLetWithSourceBindings(rewrittenFormula, processedExpressions);
         Debug.WriteLine($"Rewriting formula to: {newFormula}");
 
         WriteFormula(cell, newFormula);
+    }
+
+    /// <summary>
+    ///     Wraps a rewritten formula in a LET with _src_ bindings for each UDF,
+    ///     making plain backtick formulas compatible with rehydration and editor reopen.
+    /// </summary>
+    private static string WrapInLetWithSourceBindings(
+        string rewrittenFormula,
+        List<(string DslExpression, string UdfName, string UdfCall)> processedExpressions)
+    {
+        // Strip leading = for use as the LET result expression
+        var resultExpression = rewrittenFormula.StartsWith('=')
+            ? rewrittenFormula[1..]
+            : rewrittenFormula;
+
+        var sb = new System.Text.StringBuilder();
+        sb.Append("=LET(");
+
+        foreach (var (dslExpression, udfName, _) in processedExpressions)
+        {
+            // Strip __FB_ prefix for the _src_ key so rehydration can match it
+            // (GetDebugCallSites captures the name between __FB_ and _DEBUG)
+            var srcKey = udfName.StartsWith(CodeEmitter.UdfPrefix, StringComparison.OrdinalIgnoreCase)
+                ? udfName[CodeEmitter.UdfPrefix.Length..]
+                : udfName;
+            sb.Append("_src_").Append(srcKey).Append(", ");
+            sb.Append('"').Append(LetFormulaRewriter.EscapeForExcelString(dslExpression)).Append("\", ");
+        }
+
+        sb.Append(resultExpression);
+        sb.Append(')');
+
+        return sb.ToString();
     }
 
     private static void WriteFormula(dynamic cell, string formula)

--- a/formula-boss/Interception/LetFormulaReconstructor.cs
+++ b/formula-boss/Interception/LetFormulaReconstructor.cs
@@ -70,26 +70,42 @@ public static class LetFormulaReconstructor
             return false;
         }
 
-        // Build a flat formula, then optionally format using user's settings.
-        var sb = new StringBuilder();
-        sb.Append("=LET(");
-
+        // Collect non-machinery bindings (skip _src_ and _*_hdr)
+        var userBindings = new List<LetBinding>();
         foreach (var binding in structure.Bindings)
         {
             var varName = binding.VariableName.Trim();
 
-            // Skip _src_ bindings - they become backtick expressions
             if (varName.StartsWith(SourcePrefix, StringComparison.Ordinal))
             {
                 continue;
             }
 
-            // Skip _*_hdr header bindings - these are injected machinery for dynamic column names
             if (varName.StartsWith("_", StringComparison.Ordinal) &&
                 varName.EndsWith(HeaderSuffix, StringComparison.Ordinal))
             {
                 continue;
             }
+
+            userBindings.Add(binding);
+        }
+
+        // If there are no user bindings, this was an auto-wrapped plain backtick formula.
+        // Reconstruct as a plain formula with backtick expressions (no LET wrapper).
+        if (userBindings.Count == 0)
+        {
+            var resultExpr = ReplaceFbCallsWithBackticks(structure.ResultExpression.Trim(), sourceExpressions);
+            editableFormula = "'" + resultExpr;
+            return true;
+        }
+
+        // Build a flat formula, then optionally format using user's settings.
+        var sb = new StringBuilder();
+        sb.Append("=LET(");
+
+        foreach (var binding in userBindings)
+        {
+            var varName = binding.VariableName.Trim();
 
             sb.Append(varName);
             sb.Append(", ");
@@ -273,6 +289,103 @@ public static class LetFormulaReconstructor
     }
 
     private readonly record struct FormulaSegment(string Text, bool IsStringLiteral);
+
+    /// <summary>
+    /// Replaces __FB_* UDF calls in a formula expression with backtick DSL expressions,
+    /// using the sourceExpressions map (keyed by UDF name without __FB_ prefix).
+    /// The UDF call including its parenthesized arguments is replaced with `dslExpression`.
+    /// </summary>
+    private static string ReplaceFbCallsWithBackticks(
+        string expression,
+        Dictionary<string, string> sourceExpressions)
+    {
+        var sb = new StringBuilder();
+        var i = 0;
+
+        while (i < expression.Length)
+        {
+            // Look for __FB_ prefix
+            var fbIndex = expression.IndexOf(CodeEmitter.UdfPrefix, i, StringComparison.OrdinalIgnoreCase);
+            if (fbIndex < 0)
+            {
+                sb.Append(expression, i, expression.Length - i);
+                break;
+            }
+
+            // Append everything before the match
+            sb.Append(expression, i, fbIndex - i);
+
+            // Extract the UDF name (everything from __FB_ up to the opening parenthesis)
+            var nameStart = fbIndex + CodeEmitter.UdfPrefix.Length;
+            var parenIndex = expression.IndexOf('(', nameStart);
+            if (parenIndex < 0)
+            {
+                // No opening paren — not a UDF call, emit as-is
+                sb.Append(expression, fbIndex, expression.Length - fbIndex);
+                break;
+            }
+
+            var udfName = expression[fbIndex..parenIndex]; // e.g. __FB_AB12CD34
+
+            // _src_ keys use the name without __FB_ prefix (matching GetDebugCallSites capture group)
+            var srcKey = udfName.StartsWith(CodeEmitter.UdfPrefix, StringComparison.OrdinalIgnoreCase)
+                ? udfName[CodeEmitter.UdfPrefix.Length..]
+                : udfName;
+
+            // Check if we have a _src_ mapping for this UDF name
+            if (sourceExpressions.TryGetValue(srcKey, out var dsl))
+            {
+                // Find the matching closing paren (handle nesting)
+                var closeIndex = FindMatchingParen(expression, parenIndex);
+                if (closeIndex < 0)
+                {
+                    // Malformed — emit rest as-is
+                    sb.Append(expression, fbIndex, expression.Length - fbIndex);
+                    break;
+                }
+
+                // Replace the entire UDF call with backtick expression
+                sb.Append('`').Append(dsl).Append('`');
+                i = closeIndex + 1;
+            }
+            else
+            {
+                // No mapping — emit the UDF prefix and continue scanning
+                sb.Append(CodeEmitter.UdfPrefix);
+                i = nameStart;
+            }
+        }
+
+        // Ensure it starts with =
+        var result = sb.ToString();
+        return result.StartsWith('=') ? result : "=" + result;
+    }
+
+    /// <summary>
+    /// Finds the index of the closing parenthesis matching the opening paren at <paramref name="openIndex"/>.
+    /// </summary>
+    private static int FindMatchingParen(string text, int openIndex)
+    {
+        var depth = 1;
+        for (var j = openIndex + 1; j < text.Length; j++)
+        {
+            switch (text[j])
+            {
+                case '(':
+                    depth++;
+                    break;
+                case ')':
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return j;
+                    }
+                    break;
+            }
+        }
+
+        return -1; // unmatched
+    }
 
     /// <summary>
     /// Unescapes an Excel string literal value (removes surrounding quotes and unescapes doubled quotes).

--- a/formula-boss/Interception/LetFormulaRewriter.cs
+++ b/formula-boss/Interception/LetFormulaRewriter.cs
@@ -119,5 +119,5 @@ public static class LetFormulaRewriter
         sb.Append(')');
     }
 
-    private static string EscapeForExcelString(string value) => value.Replace("\"", "\"\"");
+    internal static string EscapeForExcelString(string value) => value.Replace("\"", "\"\"");
 }


### PR DESCRIPTION
## Summary
- Plain backtick formulas (e.g. `=``a.Sum()```) now produce `=LET(_src_HASH, "a.Sum()", __FB_HASH(A1:A5))` instead of bare `=__FB_HASH(A1:A5)`
- `LetFormulaReconstructor.TryReconstruct` updated to detect auto-wrapped formulas (no user bindings) and reconstruct them back to plain backtick form
- `LetFormulaRewriter.EscapeForExcelString` changed to `internal` for cross-class reuse

Closes #312

## Test plan
- [x] 4 new unit tests for `LetFormulaReconstructor` auto-wrapped reconstruction
- [x] 3 new AddinTests: single backtick LET structure, re-edit round-trip, multiple expressions
- [x] Full test suite passes (956 tests: 576 unit + 295 runtime + 35 integration + 50 addin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)