### PR TITLE
Bulk-read formulas during workbook-open rehydration

### DIFF
--- a/formula-boss/AddIn.cs
+++ b/formula-boss/AddIn.cs
@@ -311,6 +311,10 @@ public sealed class AddIn : IExcelAddIn, IDisposable
         var sheets = workbook.Worksheets;
         var sheetCount = (int)sheets.Count;
 
+        Logger.Info($"Rehydration: scanning {sheetCount} sheet(s)");
+
+        var totalHits = 0;
+
         for (var i = 1; i <= sheetCount; i++)
         {
             dynamic? sheet = null;
@@ -319,11 +323,12 @@ public sealed class AddIn : IExcelAddIn, IDisposable
             {
                 sheet = sheets[i];
                 usedRange = sheet.UsedRange;
-                ScanRangeForCallSites(usedRange);
+                var sheetName = (string)sheet.Name;
+                totalHits += ScanRangeForCallSites(usedRange, sheetName);
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Rehydration error on sheet {i}: {ex.Message}");
+                Logger.Error($"Rehydration sheet {i}", ex);
             }
             finally
             {
@@ -340,42 +345,55 @@ public sealed class AddIn : IExcelAddIn, IDisposable
         }
 
         Marshal.ReleaseComObject(sheets);
+
+        Logger.Info($"Rehydration: {totalHits} FB formula cell(s) processed");
     }
 
-    private void ScanRangeForCallSites(dynamic usedRange)
+    private int ScanRangeForCallSites(dynamic usedRange, string sheetName)
     {
         // Bulk-read all formulas in a single interop call. For multi-cell ranges
-        // Formula2 returns a 1-indexed object[,]; for a 1x1 range it returns the
-        // bare value. Iterating the managed array avoids one COM round-trip per
-        // cell, which dominates cost on sheets with large used ranges.
+        // Formula2 returns a 2D array; for a 1x1 range it returns the bare value.
+        // Iterating the managed array avoids one COM round-trip per cell, which
+        // dominates cost on sheets with large used ranges.
         object raw = usedRange.Formula2;
 
-        if (raw is object[,] grid)
+        if (raw is Array arr && arr.Rank == 2)
         {
-            var rows = grid.GetLength(0);
-            var cols = grid.GetLength(1);
-            var rowBase = grid.GetLowerBound(0);
-            var colBase = grid.GetLowerBound(1);
+            var rows = arr.GetLength(0);
+            var cols = arr.GetLength(1);
+            var rowBase = arr.GetLowerBound(0);
+            var colBase = arr.GetLowerBound(1);
 
+            Logger.Info(
+                $"Rehydration: sheet '{sheetName}' Formula2 is {arr.GetType().Name} " +
+                $"[{rows}x{cols}] (lower bounds {rowBase},{colBase})");
+
+            var hits = 0;
             for (var r = 0; r < rows; r++)
             {
                 for (var c = 0; c < cols; c++)
                 {
-                    ProcessFormulaCell(grid[rowBase + r, colBase + c] as string);
+                    if (ProcessFormulaCell(arr.GetValue(rowBase + r, colBase + c) as string))
+                    {
+                        hits++;
+                    }
                 }
             }
+
+            Logger.Info($"Rehydration: sheet '{sheetName}' matched {hits} FB formula cell(s)");
+            return hits;
         }
-        else
-        {
-            ProcessFormulaCell(raw as string);
-        }
+
+        var typeName = raw?.GetType().FullName ?? "<null>";
+        Logger.Info($"Rehydration: sheet '{sheetName}' Formula2 returned non-array: {typeName}");
+        return ProcessFormulaCell(raw as string) ? 1 : 0;
     }
 
-    private void ProcessFormulaCell(string? formula)
+    private bool ProcessFormulaCell(string? formula)
     {
         if (string.IsNullOrEmpty(formula) || !formula.Contains(CodeEmitter.UdfPrefix))
         {
-            return;
+            return false;
         }
 
         try
@@ -384,20 +402,23 @@ public sealed class AddIn : IExcelAddIn, IDisposable
             var normalNames = LetFormulaReconstructor.GetNormalCallSites(formula);
             if (normalNames.Count > 0)
             {
-                Debug.WriteLine($"Rehydrating normal variants for: {string.Join(", ", normalNames)}");
+                Logger.Info($"Rehydrating normal variants: {string.Join(", ", normalNames)}");
                 RehydrateCellFormulas(formula, normalNames);
             }
 
             var debugNames = LetFormulaReconstructor.GetDebugCallSites(formula);
             if (debugNames.Count > 0)
             {
-                Debug.WriteLine($"Rehydrating debug variants for: {string.Join(", ", debugNames)}");
+                Logger.Info($"Rehydrating debug variants: {string.Join(", ", debugNames)}");
                 RehydrateCellFormulas(formula, debugNames);
             }
+
+            return normalNames.Count > 0 || debugNames.Count > 0;
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Rehydration error: {ex.Message}");
+            Logger.Error("Rehydration cell", ex);
+            return false;
         }
     }
 

--- a/formula-boss/AddIn.cs
+++ b/formula-boss/AddIn.cs
@@ -310,9 +310,6 @@ public sealed class AddIn : IExcelAddIn, IDisposable
 
         var sheets = workbook.Worksheets;
         var sheetCount = (int)sheets.Count;
-
-        Logger.Info($"Rehydration: scanning {sheetCount} sheet(s)");
-
         var totalHits = 0;
 
         for (var i = 1; i <= sheetCount; i++)
@@ -323,8 +320,7 @@ public sealed class AddIn : IExcelAddIn, IDisposable
             {
                 sheet = sheets[i];
                 usedRange = sheet.UsedRange;
-                var sheetName = (string)sheet.Name;
-                totalHits += ScanRangeForCallSites(usedRange, sheetName);
+                totalHits += ScanRangeForCallSites(usedRange);
             }
             catch (Exception ex)
             {
@@ -346,10 +342,13 @@ public sealed class AddIn : IExcelAddIn, IDisposable
 
         Marshal.ReleaseComObject(sheets);
 
-        Logger.Info($"Rehydration: {totalHits} FB formula cell(s) processed");
+        if (totalHits > 0)
+        {
+            Logger.Info($"Rehydration: scanned {sheetCount} sheet(s), processed {totalHits} FB cell(s)");
+        }
     }
 
-    private int ScanRangeForCallSites(dynamic usedRange, string sheetName)
+    private int ScanRangeForCallSites(dynamic usedRange)
     {
         // Bulk-read all formulas in a single interop call. For multi-cell ranges
         // Formula2 returns a 2D array; for a 1x1 range it returns the bare value.
@@ -364,10 +363,6 @@ public sealed class AddIn : IExcelAddIn, IDisposable
             var rowBase = arr.GetLowerBound(0);
             var colBase = arr.GetLowerBound(1);
 
-            Logger.Info(
-                $"Rehydration: sheet '{sheetName}' Formula2 is {arr.GetType().Name} " +
-                $"[{rows}x{cols}] (lower bounds {rowBase},{colBase})");
-
             var hits = 0;
             for (var r = 0; r < rows; r++)
             {
@@ -380,12 +375,9 @@ public sealed class AddIn : IExcelAddIn, IDisposable
                 }
             }
 
-            Logger.Info($"Rehydration: sheet '{sheetName}' matched {hits} FB formula cell(s)");
             return hits;
         }
 
-        var typeName = raw?.GetType().FullName ?? "<null>";
-        Logger.Info($"Rehydration: sheet '{sheetName}' Formula2 returned non-array: {typeName}");
         return ProcessFormulaCell(raw as string) ? 1 : 0;
     }
 
@@ -402,14 +394,12 @@ public sealed class AddIn : IExcelAddIn, IDisposable
             var normalNames = LetFormulaReconstructor.GetNormalCallSites(formula);
             if (normalNames.Count > 0)
             {
-                Logger.Info($"Rehydrating normal variants: {string.Join(", ", normalNames)}");
                 RehydrateCellFormulas(formula, normalNames);
             }
 
             var debugNames = LetFormulaReconstructor.GetDebugCallSites(formula);
             if (debugNames.Count > 0)
             {
-                Logger.Info($"Rehydrating debug variants: {string.Join(", ", debugNames)}");
                 RehydrateCellFormulas(formula, debugNames);
             }
 

--- a/formula-boss/AddIn.cs
+++ b/formula-boss/AddIn.cs
@@ -344,50 +344,60 @@ public sealed class AddIn : IExcelAddIn, IDisposable
 
     private void ScanRangeForCallSites(dynamic usedRange)
     {
-        var rows = (int)usedRange.Rows.Count;
-        var cols = (int)usedRange.Columns.Count;
+        // Bulk-read all formulas in a single interop call. For multi-cell ranges
+        // Formula2 returns a 1-indexed object[,]; for a 1x1 range it returns the
+        // bare value. Iterating the managed array avoids one COM round-trip per
+        // cell, which dominates cost on sheets with large used ranges.
+        object raw = usedRange.Formula2;
 
-        for (var r = 1; r <= rows; r++)
+        if (raw is object[,] grid)
         {
-            for (var c = 1; c <= cols; c++)
+            var rows = grid.GetLength(0);
+            var cols = grid.GetLength(1);
+            var rowBase = grid.GetLowerBound(0);
+            var colBase = grid.GetLowerBound(1);
+
+            for (var r = 0; r < rows; r++)
             {
-                dynamic? cell = null;
-                try
+                for (var c = 0; c < cols; c++)
                 {
-                    cell = usedRange.Cells[r, c];
-                    var formula = cell.Formula2 as string;
-                    if (string.IsNullOrEmpty(formula) || !formula.Contains(CodeEmitter.UdfPrefix))
-                    {
-                        continue;
-                    }
-
-                    // Rehydrate normal variants first, then debug variants
-                    var normalNames = LetFormulaReconstructor.GetNormalCallSites(formula);
-                    if (normalNames.Count > 0)
-                    {
-                        Debug.WriteLine($"Rehydrating normal variants for: {string.Join(", ", normalNames)}");
-                        RehydrateCellFormulas(formula, normalNames);
-                    }
-
-                    var debugNames = LetFormulaReconstructor.GetDebugCallSites(formula);
-                    if (debugNames.Count > 0)
-                    {
-                        Debug.WriteLine($"Rehydrating debug variants for: {string.Join(", ", debugNames)}");
-                        RehydrateCellFormulas(formula, debugNames);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"Rehydration error at cell [{r},{c}]: {ex.Message}");
-                }
-                finally
-                {
-                    if (cell != null)
-                    {
-                        Marshal.ReleaseComObject(cell);
-                    }
+                    ProcessFormulaCell(grid[rowBase + r, colBase + c] as string);
                 }
             }
+        }
+        else
+        {
+            ProcessFormulaCell(raw as string);
+        }
+    }
+
+    private void ProcessFormulaCell(string? formula)
+    {
+        if (string.IsNullOrEmpty(formula) || !formula.Contains(CodeEmitter.UdfPrefix))
+        {
+            return;
+        }
+
+        try
+        {
+            // Rehydrate normal variants first, then debug variants
+            var normalNames = LetFormulaReconstructor.GetNormalCallSites(formula);
+            if (normalNames.Count > 0)
+            {
+                Debug.WriteLine($"Rehydrating normal variants for: {string.Join(", ", normalNames)}");
+                RehydrateCellFormulas(formula, normalNames);
+            }
+
+            var debugNames = LetFormulaReconstructor.GetDebugCallSites(formula);
+            if (debugNames.Count > 0)
+            {
+                Debug.WriteLine($"Rehydrating debug variants for: {string.Join(", ", debugNames)}");
+                RehydrateCellFormulas(formula, debugNames);
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Rehydration error: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
Closes #318

## Summary
- `ScanRangeForCallSites` now reads the entire used range's formulas in a single `usedRange.Formula2` interop call, then iterates the resulting `object[,]` in managed code.
- Previously, every cell in the used range cost one `Cells[r, c]` COM access plus one `Formula2` read plus one `Marshal.ReleaseComObject` — a 200×50 used range = 10,000+ round-trips regardless of how many FB formulas were present.
- Handles the 1×1 case (Excel returns the bare value, not a `object[,]`) and the lower-bound of the returned array (it's 1-indexed).

## Test plan
- [x] `dotnet build formula-boss/formula-boss.slnx` — succeeds
- [x] `dotnet test formula-boss.AddinTests` — 52/52 pass (exercises the real rehydration path in a live Excel instance)
- [x] `dotnet test formula-boss.Runtime.Tests` — 295/295 pass
- [x] Open a medium workbook (no FB formulas) and confirm open is near-instant
- [x] Open a workbook containing FB formulas and confirm they rehydrate correctly (normal + debug variants)