### PR TITLE
Fix column completion replacing entire formula prefix (#324)

### DIFF
--- a/formula-boss.Tests/CompletionPopupTests.cs
+++ b/formula-boss.Tests/CompletionPopupTests.cs
@@ -1,0 +1,206 @@
+using FormulaBoss.UI;
+using FormulaBoss.UI.Completion;
+
+using ICSharpCode.AvalonEdit;
+
+using Xunit;
+
+namespace FormulaBoss.Tests;
+
+public class CompletionPopupTests
+{
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw caught;
+        }
+    }
+
+    private static (TextEditor editor, CompletionPopup popup) CreatePopup(string text, int caretOffset)
+    {
+        var editor = new TextEditor { Text = text, CaretOffset = caretOffset };
+        var popup = new CompletionPopup(editor.TextArea);
+        return (editor, popup);
+    }
+
+    [Fact]
+    public void Show_with_unset_StartOffset_initializes_to_caret_offset() => RunOnSta(() =>
+    {
+        // Repro for issue #324 1a: caller forgets to set StartOffset (e.g. wordLength == 0
+        // path before the fix). Show() must default StartOffset to the caret offset so the
+        // would-be replacement segment is empty rather than [0, caret).
+        var (_, popup) = CreatePopup("var myRow = t.Rows.First(); return myRow.", 41);
+        try
+        {
+            popup.Show();
+            Assert.Equal(41, popup.StartOffset);
+        }
+        finally
+        {
+            popup.Close();
+        }
+    });
+
+    [Fact]
+    public void Show_with_explicit_StartOffset_preserves_value() => RunOnSta(() =>
+    {
+        // Caller has computed wordLength > 0 and set StartOffset back to the start of the
+        // typed prefix — Show must not overwrite it.
+        var (_, popup) = CreatePopup("r.Pl", 4);
+        popup.StartOffset = 2;
+        try
+        {
+            popup.Show();
+            Assert.Equal(2, popup.StartOffset);
+        }
+        finally
+        {
+            popup.Close();
+        }
+    });
+
+    [Fact]
+    public void Show_with_StartOffset_beyond_caret_is_clamped_to_caret() => RunOnSta(() =>
+    {
+        // Defensive: a StartOffset beyond the caret would yield a negative segment length.
+        // Show should clamp it back to the caret offset.
+        var (_, popup) = CreatePopup("hello", 3);
+        popup.StartOffset = 100;
+        try
+        {
+            popup.Show();
+            Assert.Equal(3, popup.StartOffset);
+        }
+        finally
+        {
+            popup.Close();
+        }
+    });
+
+    [Fact]
+    public void Show_with_zero_StartOffset_at_zero_caret_is_valid() => RunOnSta(() =>
+    {
+        // StartOffset == 0 is legitimate when the caret is also at 0 (empty document).
+        var (_, popup) = CreatePopup("", 0);
+        popup.StartOffset = 0;
+        try
+        {
+            popup.Show();
+            Assert.Equal(0, popup.StartOffset);
+        }
+        finally
+        {
+            popup.Close();
+        }
+    });
+
+    [Fact]
+    public void Insertion_with_empty_segment_at_dot_offset_replaces_only_dot_via_ColumnCompletion() => RunOnSta(() =>
+    {
+        // End-to-end coverage of issue #324 1a: with the bug, StartOffset was 0 and Enter
+        // would replace the entire formula. With the fix, StartOffset == caret, so the
+        // ColumnCompletionData rewrites only the dot to bracket syntax.
+        var formula = "var myRow = t.Rows.First(); return myRow.";
+        var (editor, popup) = CreatePopup(formula, formula.Length);
+        var item = new ColumnCompletionData("Player", "Column name", isBracketContext: false);
+        popup.CompletionList.CompletionData.Add(item);
+        popup.CompletionList.SelectedItem = item;
+
+        try
+        {
+            popup.Show();
+            popup.CompletionList.RequestInsertion(EventArgs.Empty);
+        }
+        finally
+        {
+            // RequestInsertion calls Close internally; avoid double-close
+            if (popup.IsOpen)
+            {
+                popup.Close();
+            }
+        }
+
+        Assert.Equal("var myRow = t.Rows.First(); return myRow[\"Player\"]", editor.Text);
+    });
+
+    [Fact]
+    public void Insertion_after_typed_prefix_replaces_dot_and_prefix() => RunOnSta(() =>
+    {
+        // Issue #324 acceptance: typing `myRow.Player` then Enter rewrites to myRow["Player"]
+        // and does not touch the surrounding text.
+        var formula = "var myRow = t.Rows.First(); return myRow.";
+        var (editor, popup) = CreatePopup(formula, formula.Length);
+        var item = new ColumnCompletionData("Player", "Column name", isBracketContext: false);
+        popup.CompletionList.CompletionData.Add(item);
+        popup.CompletionList.SelectedItem = item;
+
+        try
+        {
+            popup.Show();
+
+            // User types "Player" after the dot — document inserts shift _endOffset
+            editor.Document.Insert(editor.CaretOffset, "Player");
+
+            popup.CompletionList.RequestInsertion(EventArgs.Empty);
+        }
+        finally
+        {
+            if (popup.IsOpen)
+            {
+                popup.Close();
+            }
+        }
+
+        Assert.Equal("var myRow = t.Rows.First(); return myRow[\"Player\"]", editor.Text);
+    });
+
+    [Fact]
+    public void Insertion_in_column_mode_with_single_char_column_uses_bracket_rewrite() => RunOnSta(() =>
+    {
+        // Repro for issue #324 1b: column "1" / typed "1". Even if AvalonEdit's filter
+        // empties the visible list, the popup must stay open in column mode and Enter
+        // must still trigger the bracket rewrite.
+        var formula = "r.";
+        var (editor, popup) = CreatePopup(formula, formula.Length);
+        var col1 = new ColumnCompletionData("1", "Column name", isBracketContext: false);
+        var col2 = new ColumnCompletionData("2", "Column name", isBracketContext: false);
+        var col3 = new ColumnCompletionData("3", "Column name", isBracketContext: false);
+        popup.CompletionList.CompletionData.Add(col1);
+        popup.CompletionList.CompletionData.Add(col2);
+        popup.CompletionList.CompletionData.Add(col3);
+        popup.CompletionList.SelectedItem = col1;
+        popup.IsColumnCompletion = true;
+
+        try
+        {
+            popup.Show();
+
+            // User types "1"
+            editor.Document.Insert(editor.CaretOffset, "1");
+
+            popup.CompletionList.RequestInsertion(EventArgs.Empty);
+        }
+        finally
+        {
+            if (popup.IsOpen)
+            {
+                popup.Close();
+            }
+        }
+
+        Assert.Equal("r[\"1\"]", editor.Text);
+    });
+}

--- a/formula-boss/UI/Completion/CompletionPopup.cs
+++ b/formula-boss/UI/Completion/CompletionPopup.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -26,6 +27,7 @@ internal sealed class CompletionPopup
 
     private readonly TextArea _textArea;
     private int _endOffset;
+    private int _startOffset = -1;
 
     public CompletionPopup(TextArea textArea)
     {
@@ -58,9 +60,27 @@ internal sealed class CompletionPopup
 
     public CompletionList CompletionList { get; }
 
-    public int StartOffset { get; set; }
+    /// <summary>
+    ///     Offset of the start of the user's typed prefix (i.e. where insertion replaces from).
+    ///     Defaults to -1 as a sentinel; if not assigned by the caller before <see cref="Show"/>,
+    ///     it is initialized to the caret offset (an empty replacement segment).
+    /// </summary>
+    public int StartOffset
+    {
+        get => _startOffset;
+        set => _startOffset = value;
+    }
 
     public bool CloseWhenCaretAtBeginning { get; set; }
+
+    /// <summary>
+    ///     True when the popup is hosting column completions (dot-rewrite or bracket).
+    ///     The value-add of these completions is the bracket transformation on commit,
+    ///     not filtering — so when AvalonEdit's filter empties the visible list because
+    ///     the typed prefix exactly matches an item, the popup stays open with that item
+    ///     selected so Enter/Tab still triggers the rewrite.
+    /// </summary>
+    public bool IsColumnCompletion { get; set; }
 
     public bool IsOpen => _popup.IsOpen;
 
@@ -69,6 +89,14 @@ internal sealed class CompletionPopup
     public void Show()
     {
         _endOffset = _textArea.Caret.Offset;
+
+        // Defensive default: if caller forgot to set StartOffset, treat the segment
+        // as empty (no prefix to replace) rather than [0, caret) which would replace
+        // the entire formula on commit.
+        if (_startOffset < 0 || _startOffset > _endOffset)
+        {
+            _startOffset = _endOffset;
+        }
 
         _textArea.Document.Changing += OnDocumentChanging;
         _textArea.Caret.PositionChanged += OnCaretPositionChanged;
@@ -141,6 +169,14 @@ internal sealed class CompletionPopup
         var endOffset = _endOffset;
         Close();
 
+        // Defensive: a corrupted [start, end) range (e.g. start=0 with non-empty doc when
+        // the popup opened with no prefix) would otherwise replace text outside the typed
+        // prefix span. Refuse to commit a non-empty completion with an invalid range.
+        if (startOffset < 0 || endOffset < startOffset || endOffset > _textArea.Document.TextLength)
+        {
+            return;
+        }
+
         var segment = new AnchorSegment(_textArea.Document, startOffset, endOffset - startOffset);
         item.Complete(_textArea, segment, e);
     }
@@ -186,15 +222,58 @@ internal sealed class CompletionPopup
         var text = _textArea.Document.GetText(StartOffset, caretOffset - StartOffset);
         CompletionList.SelectItem(text);
 
-        // If filtering left no visible items, close
+        // If filtering left no visible items, close — except for column completion,
+        // where the typed prefix exactly matching an item (e.g. column "1" + user types "1")
+        // can cause AvalonEdit to drop the item from the visible list. In that case keep
+        // the popup open with the matching item selected so Enter/Tab still rewrites to
+        // bracket syntax.
         if (CompletionList.ListBox?.Items.Count == 0)
         {
+            if (IsColumnCompletion && TryReselectExactColumnMatch(text))
+            {
+                _popup.HorizontalOffset = 0;
+                return;
+            }
+
             Close();
             return;
         }
 
         // Force popup to reposition to follow the caret
         _popup.HorizontalOffset = 0;
+    }
+
+    /// <summary>
+    ///     When AvalonEdit's filter has emptied the visible list, look for a column
+    ///     completion item whose text exactly matches the typed prefix. If found, repopulate
+    ///     the listbox with just that item and select it so a subsequent Enter/Tab triggers
+    ///     <see cref="OnInsertionRequested"/>.
+    /// </summary>
+    private bool TryReselectExactColumnMatch(string typedPrefix)
+    {
+        if (string.IsNullOrEmpty(typedPrefix) || CompletionList.ListBox == null)
+        {
+            return false;
+        }
+
+        ICompletionData? match = null;
+        foreach (var data in CompletionList.CompletionData)
+        {
+            if (data.Text.Equals(typedPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                match = data;
+                break;
+            }
+        }
+
+        if (match == null)
+        {
+            return false;
+        }
+
+        CompletionList.ListBox.ItemsSource = new ObservableCollection<ICompletionData> { match };
+        CompletionList.SelectedItem = match;
+        return true;
     }
 
     private void OnPreviewKeyDown(object sender, KeyEventArgs e)

--- a/formula-boss/UI/FloatingEditorWindow.xaml.cs
+++ b/formula-boss/UI/FloatingEditorWindow.xaml.cs
@@ -266,13 +266,10 @@ public partial class FloatingEditorWindow
 
         _completionPopup = new CompletionPopup(FormulaEditor.TextArea)
         {
-            CloseWhenCaretAtBeginning = true
+            CloseWhenCaretAtBeginning = true,
+            StartOffset = FormulaEditor.CaretOffset - wordLength,
+            IsColumnCompletion = items.Any(i => i is ColumnCompletionData)
         };
-
-        if (wordLength > 0)
-        {
-            _completionPopup.StartOffset = FormulaEditor.CaretOffset - wordLength;
-        }
 
         foreach (var item in items)
         {


### PR DESCRIPTION
## Summary

Fixes two related bugs in the column-name completion path described in #324.

- **1a (data loss):** `CompletionPopup.StartOffset` was only set when `wordLength > 0`. After typing `myRow.` (where `myRow` is a synthetic row type detected by Roslyn), the popup opened with `wordLength == 0` and `StartOffset` kept its default of `0`. Pressing Enter replaced the entire formula prefix with `["ColumnName"]`.
- **1b (single-char columns):** With column names like `"1"`/`"2"`/`"3"`, typing `r.` then `1` caused AvalonEdit's filter to drop the matching item, the popup closed via the empty-filter check, and the bracket rewrite never fired — leaving the user with the invalid `r.1`.

## Changes

- `formula-boss/UI/FloatingEditorWindow.xaml.cs` — always set `StartOffset` (no longer guarded by `wordLength > 0`); set `IsColumnCompletion` when items are `ColumnCompletionData`.
- `formula-boss/UI/Completion/CompletionPopup.cs`:
  - `StartOffset` defaults to `-1` sentinel; `Show()` clamps to caret offset if unset or beyond caret.
  - `OnInsertionRequested` refuses to commit a corrupted range as a last line of defense.
  - New `IsColumnCompletion` flag: when the filter empties the visible list in this mode and the typed prefix exactly matches a column item, repopulate the listbox and re-select so Enter/Tab still triggers the bracket rewrite.
- `formula-boss.Tests/CompletionPopupTests.cs` — 7 new tests covering both repros and the defensive clamps.

## Test plan

- [x] `dotnet build formula-boss/formula-boss.slnx` — clean
- [x] `dotnet test formula-boss/formula-boss.slnx` — 971 passed, 0 failed (incl. 52 AddIn tests)
- [x] Acceptance #1 (`myRow.Player` Enter → `myRow["Player"]`, surrounding text untouched) covered by `Insertion_after_typed_prefix_replaces_dot_and_prefix`
- [x] Acceptance #3 (`r.` + `1` Enter → `r["1"]`) covered by `Insertion_in_column_mode_with_single_char_column_uses_bracket_rewrite`
- [x] Acceptance #2 (no keystroke can replace text outside `[StartOffset, caretOffset)`) covered by the defensive clamps in `Show()` and `OnInsertionRequested` plus `Show_with_unset_StartOffset_initializes_to_caret_offset` and `Show_with_StartOffset_beyond_caret_is_clamped_to_caret`

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)