### PR TITLE
Show LINQ surface on Row IntelliSense alongside column headers

### DIFF
--- a/formula-boss.Tests/RoslynCompletionTests.cs
+++ b/formula-boss.Tests/RoslynCompletionTests.cs
@@ -223,8 +223,35 @@ public class RoslynCompletionTests : IDisposable
         Assert.Contains("Amount", texts);
         Assert.Contains("Region", texts);
 
-        // Items should be ColumnCompletionData (bracket-inserting), not plain CompletionData
-        Assert.All(items, item => Assert.IsType<ColumnCompletionData>(item));
+        // Column-name items insert as bracket syntax (ColumnCompletionData);
+        // LINQ/ExcelArray members are regular CompletionData and must coexist.
+        var columnItems = items.Where(i => i is ColumnCompletionData).Select(i => i.Text).ToList();
+        Assert.Contains("Date", columnItems);
+        Assert.Contains("Amount", columnItems);
+        Assert.Contains("Region", columnItems);
+    }
+
+    [Fact]
+    public async Task RowAfterFirst_AlsoShowsLinqAndExcelArrayMembers()
+    {
+        // Issue #325: a Row obtained via .First()/.Single() should expose its LINQ surface
+        // (Skip, Where, FirstOrDefault, Map, ...) alongside the column headers.
+        var formula = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).`)";
+        var textUp = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        var texts = items.Select(i => i.Text).ToList();
+        Assert.Contains("Skip", texts);
+        Assert.Contains("Where", texts);
+        Assert.Contains("FirstOrDefault", texts);
+        Assert.Contains("Map", texts);
+
+        // LINQ members must be plain CompletionData so they insert as `.Skip(...)`,
+        // not as bracket syntax.
+        Assert.All(items.Where(i => i.Text is "Skip" or "Where" or "FirstOrDefault" or "Map"),
+            item => Assert.IsNotType<ColumnCompletionData>(item));
     }
 
     [Fact]
@@ -240,7 +267,45 @@ public class RoslynCompletionTests : IDisposable
         Assert.Contains("Date", texts);
         Assert.Contains("Amount", texts);
         Assert.Contains("Region", texts);
-        Assert.All(items, item => Assert.IsType<ColumnCompletionData>(item));
+
+        var columnItems = items.Where(i => i is ColumnCompletionData).Select(i => i.Text).ToList();
+        Assert.Contains("Date", columnItems);
+        Assert.Contains("Amount", columnItems);
+        Assert.Contains("Region", columnItems);
+    }
+
+    [Fact]
+    public async Task RowLambdaParam_ShowsColumnsAndLinqMembers()
+    {
+        // Lambda parameter on a Row context (.Rows.Where(r => r.)) should also expose
+        // the LINQ surface alongside columns.
+        var formula = "=LET(t, Sales, `t.Rows.Where(r => r.`)";
+        var textUp = "=LET(t, Sales, `t.Rows.Where(r => r.";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        var texts = items.Select(i => i.Text).ToList();
+        Assert.Contains("Date", texts);
+        Assert.Contains("Skip", texts);
+        Assert.Contains("FirstOrDefault", texts);
+    }
+
+    [Fact]
+    public async Task Row_ColumnNamesNotDuplicated()
+    {
+        // The synthetic Row class emits column-name properties for Roslyn; the bracket-
+        // syntax versions come from BuildRowCompletions. The merge must not list a
+        // column twice.
+        var formula = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).`)";
+        var textUp = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        Assert.Single(items, i => i.Text == "Date");
+        Assert.Single(items, i => i.Text == "Amount");
+        Assert.Single(items, i => i.Text == "Region");
     }
 
     [Fact]

--- a/formula-boss.Tests/RoslynCompletionTests.cs
+++ b/formula-boss.Tests/RoslynCompletionTests.cs
@@ -292,6 +292,25 @@ public class RoslynCompletionTests : IDisposable
     }
 
     [Fact]
+    public async Task Row_ColumnsListedBeforeLinqMembers()
+    {
+        // Columns are the most common completion target on a Row — list them first so the
+        // user sees them before having to scroll past the inherited ExcelArray surface.
+        var formula = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).`)";
+        var textUp = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).";
+
+        var (items, _) = await _provider.GetCompletionsAsync(
+            textUp, formula, SalesMetadata, CancellationToken.None);
+
+        var lastColumnIndex = items.ToList().FindLastIndex(i => i is ColumnCompletionData);
+        var firstLinqIndex = items.ToList().FindIndex(i => i.Text is "Skip" or "Where" or "FirstOrDefault");
+        Assert.True(lastColumnIndex >= 0 && firstLinqIndex >= 0,
+            "Both column and LINQ items should be present");
+        Assert.True(lastColumnIndex < firstLinqIndex,
+            $"Columns should precede LINQ members but lastColumn={lastColumnIndex}, firstLinq={firstLinqIndex}");
+    }
+
+    [Fact]
     public async Task Row_ColumnNamesNotDuplicated()
     {
         // The synthetic Row class emits column-name properties for Roslyn; the bracket-

--- a/formula-boss.Tests/SyntheticDocumentBuilderTests.cs
+++ b/formula-boss.Tests/SyntheticDocumentBuilderTests.cs
@@ -1,5 +1,9 @@
+using FormulaBoss.Compilation;
 using FormulaBoss.UI;
 using FormulaBoss.UI.Completion;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 using Xunit;
 
@@ -161,5 +165,61 @@ public class SyntheticDocumentBuilderTests
 
         var (source, _) = SyntheticDocumentBuilder.Build(formula, textUp, TwoTableMetadata);
         Assert.Contains("ExcelArray r = default!", source);
+    }
+
+    [Fact]
+    public void Build_TypedRowClass_InheritsExcelArray()
+    {
+        var (source, _) = SyntheticDocumentBuilder.Build("=`Sales.`", "=`Sales.", TwoTableMetadata);
+        Assert.Contains("class __SalesRow : ExcelArray", source);
+    }
+
+    [Fact]
+    public void BuildForDiagnostics_LinqOnRow_CompilesWithoutDiagnostics()
+    {
+        // Mirrors the issue's repro: LINQ-style methods on a Row resolved via .First()
+        // should be valid C# in the synthetic document.
+        var formula = "=`Sales.Rows.First().Skip(1).FirstOrDefault(p => p != null)`";
+
+        AssertSyntheticDiagnosticFree(formula, TwoTableMetadata);
+    }
+
+    [Fact]
+    public void BuildForDiagnostics_ExcelArrayMethodsOnRow_CompilesWithoutDiagnostics()
+    {
+        // ExcelArray surface (Where, Map, Skip, Take, Count) on a Row.
+        var formula = "=`Sales.Rows.First().Skip(1).Where(s => s != null).Map(s => s).Take(2).Count()`";
+
+        AssertSyntheticDiagnosticFree(formula, TwoTableMetadata);
+    }
+
+    private static void AssertSyntheticDiagnosticFree(string formula, WorkbookMetadata metadata)
+    {
+        var result = SyntheticDocumentBuilder.BuildForDiagnostics(formula, metadata);
+        Assert.NotNull(result);
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(result.Source);
+        var compilation = CSharpCompilation.Create(
+            "DiagnosticCheck",
+            new[] { syntaxTree },
+            MetadataReferenceProvider.GetMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        // Only check diagnostics that fall within the embedded expression — errors elsewhere
+        // (e.g. ambiguous overloads in the synthetic stubs) aren't what this test is verifying.
+        var exprStart = result.ExpressionStartInSynthetic;
+        var exprEnd = exprStart + result.ExpressionLength;
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d =>
+            {
+                var span = d.Location.SourceSpan;
+                return span.Start >= exprStart && span.End <= exprEnd;
+            })
+            .Select(d => d.ToString())
+            .ToList();
+
+        Assert.True(errors.Count == 0,
+            $"Expected no diagnostic errors on embedded expression but got:\n{string.Join("\n", errors)}\n\nSource:\n{result.Source}");
     }
 }

--- a/formula-boss.Tests/TypedDocumentBuilderTests.cs
+++ b/formula-boss.Tests/TypedDocumentBuilderTests.cs
@@ -91,7 +91,7 @@ public class TypedDocumentBuilderTests
         TypedDocumentBuilder.EmitTableTypes(sb, SingleTableMetadata);
         var source = sb.ToString();
 
-        Assert.Contains("class __SalesRow {", source);
+        Assert.Contains("class __SalesRow : ExcelArray {", source);
         Assert.Contains("public ExcelScalar Date => default!;", source);
         Assert.Contains("public ExcelScalar Amount => default!;", source);
         Assert.Contains("public ExcelScalar Region => default!;", source);

--- a/formula-boss/Analysis/TypedDocumentBuilder.cs
+++ b/formula-boss/Analysis/TypedDocumentBuilder.cs
@@ -103,13 +103,13 @@ internal static class TypedDocumentBuilder
 
     private static void EmitTypedRow(StringBuilder sb, string rowTypeName, IReadOnlyList<string> columns)
     {
-        sb.AppendLine($"class {rowTypeName} {{");
+        // Inherit ExcelArray so synthetic Row exposes the same LINQ/ExcelArray surface
+        // (Skip, Where, Map, FirstOrDefault, ...) as the runtime Row : ExcelArray type.
+        sb.AppendLine($"class {rowTypeName} : ExcelArray {{");
+        sb.AppendLine($"{rowTypeName}() : base(new object[0,0]) {{}}");
 
-        // Indexer for bracket access
+        // Row-specific members not present on ExcelArray
         sb.AppendLine("public ExcelScalar this[string columnName] => default!;");
-        sb.AppendLine("public ExcelScalar this[int index] => default!;");
-        sb.AppendLine("public int RowCount => 0;");
-        sb.AppendLine("public int ColCount => 0;");
         sb.AppendLine("public int ColumnCount => 0;");
 
         var mapping = ColumnMapper.BuildMapping(columns.ToArray());

--- a/formula-boss/UI/Completion/CompletionPopup.cs
+++ b/formula-boss/UI/Completion/CompletionPopup.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -27,7 +27,6 @@ internal sealed class CompletionPopup
 
     private readonly TextArea _textArea;
     private int _endOffset;
-    private int _startOffset = -1;
 
     public CompletionPopup(TextArea textArea)
     {
@@ -62,14 +61,10 @@ internal sealed class CompletionPopup
 
     /// <summary>
     ///     Offset of the start of the user's typed prefix (i.e. where insertion replaces from).
-    ///     Defaults to -1 as a sentinel; if not assigned by the caller before <see cref="Show"/>,
+    ///     Defaults to -1 as a sentinel; if not assigned by the caller before <see cref="Show" />,
     ///     it is initialized to the caret offset (an empty replacement segment).
     /// </summary>
-    public int StartOffset
-    {
-        get => _startOffset;
-        set => _startOffset = value;
-    }
+    public int StartOffset { get; set; } = -1;
 
     public bool CloseWhenCaretAtBeginning { get; set; }
 
@@ -93,9 +88,9 @@ internal sealed class CompletionPopup
         // Defensive default: if caller forgot to set StartOffset, treat the segment
         // as empty (no prefix to replace) rather than [0, caret) which would replace
         // the entire formula on commit.
-        if (_startOffset < 0 || _startOffset > _endOffset)
+        if (StartOffset < 0 || StartOffset > _endOffset)
         {
-            _startOffset = _endOffset;
+            StartOffset = _endOffset;
         }
 
         _textArea.Document.Changing += OnDocumentChanging;
@@ -247,7 +242,7 @@ internal sealed class CompletionPopup
     ///     When AvalonEdit's filter has emptied the visible list, look for a column
     ///     completion item whose text exactly matches the typed prefix. If found, repopulate
     ///     the listbox with just that item and select it so a subsequent Enter/Tab triggers
-    ///     <see cref="OnInsertionRequested"/>.
+    ///     <see cref="OnInsertionRequested" />.
     /// </summary>
     private bool TryReselectExactColumnMatch(string typedPrefix)
     {

--- a/formula-boss/UI/Completion/RoslynCompletionProvider.cs
+++ b/formula-boss/UI/Completion/RoslynCompletionProvider.cs
@@ -36,13 +36,6 @@ internal sealed class RoslynCompletionProvider
             return (items, true);
         }
 
-        // Row dot context: show column names that insert as bracket syntax
-        if (ctx.Type == DslType.Row)
-        {
-            var items = CompletionHelpers.GetDotColumnCompletions(textUpToCaret, fullText, metadata);
-            return (items, false);
-        }
-
         // Outside DSL: use top-level completions (table names, LET variables).
         // Check cursor context (InsideDsl), not whether formula contains backticks elsewhere.
         if (!ctx.InsideDsl)
@@ -63,23 +56,31 @@ internal sealed class RoslynCompletionProvider
         var roslynItems = await _workspace.GetCompletionsAsync(
             syntheticSource, caretOffset, cancellationToken);
 
-        if (roslynItems.Count == 0)
-        {
-            return (Array.Empty<CompletionData>(), false);
-        }
-
-        // Get the type before the dot once for both Row and Table detection
+        // Get the type before the dot once for both Row and Table detection.
+        // We need this even when Roslyn returns no items (e.g. lambda parameter on Row)
+        // so we can still emit column completions.
         var typeName = metadata != null
             ? await _workspace.GetTypeBeforeDotAsync(caretOffset, cancellationToken)
             : null;
 
-        // Check if the expression before the dot is a Row type — if so,
-        // replace Roslyn's property completions with bracket-inserting column completions
+        // Check if the expression before the dot is a Row type — if so, augment Roslyn's
+        // completions (LINQ/ExcelArray surface) with bracket-inserting column completions.
+        // Filter the synthetic column-name properties from Roslyn so they don't duplicate
+        // the bracket-syntax versions emitted by BuildRowCompletions.
         var rowTableName = ResolveTableNameFromType(typeName, metadata, @"^__(.+)Row$");
         if (rowTableName != null)
         {
             var columnItems = CompletionHelpers.BuildRowCompletions(metadata, false, rowTableName);
-            return (columnItems, false);
+            var sanitisedColumns = GetSanitisedColumnNames(rowTableName, metadata);
+            var roslynResult = MapCompletionItems(roslynItems);
+            roslynResult.RemoveAll(item => sanitisedColumns.Contains(item.Text));
+            roslynResult.AddRange(columnItems);
+            return (roslynResult, false);
+        }
+
+        if (roslynItems.Count == 0)
+        {
+            return (Array.Empty<CompletionData>(), false);
         }
 
         // Check if the expression before the dot is a Table type — if so,
@@ -95,6 +96,29 @@ internal sealed class RoslynCompletionProvider
 
         var result = MapCompletionItems(roslynItems);
         return (result, false);
+    }
+
+    /// <summary>
+    ///     Returns the set of sanitised column-name property identifiers emitted on the
+    ///     synthetic Row class for a given table. Used to strip these synthetic stubs
+    ///     from Roslyn's completion list so they don't duplicate the bracket-syntax
+    ///     column completions.
+    /// </summary>
+    private static HashSet<string> GetSanitisedColumnNames(string tableName, WorkbookMetadata? metadata)
+    {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        if (metadata == null ||
+            !metadata.TableColumns.TryGetValue(tableName, out var columns))
+        {
+            return result;
+        }
+
+        foreach (var (sanitised, _) in ColumnMapper.BuildMapping(columns.ToArray()))
+        {
+            result.Add(sanitised);
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/formula-boss/UI/Completion/RoslynCompletionProvider.cs
+++ b/formula-boss/UI/Completion/RoslynCompletionProvider.cs
@@ -67,15 +67,19 @@ internal sealed class RoslynCompletionProvider
         // completions (LINQ/ExcelArray surface) with bracket-inserting column completions.
         // Filter the synthetic column-name properties from Roslyn so they don't duplicate
         // the bracket-syntax versions emitted by BuildRowCompletions.
+        // Columns are listed first because they're the most common Row completion target —
+        // the AvalonEdit CompletionList renders items in insertion order.
         var rowTableName = ResolveTableNameFromType(typeName, metadata, @"^__(.+)Row$");
         if (rowTableName != null)
         {
-            var columnItems = CompletionHelpers.BuildRowCompletions(metadata, false, rowTableName);
             var sanitisedColumns = GetSanitisedColumnNames(rowTableName, metadata);
-            var roslynResult = MapCompletionItems(roslynItems);
-            roslynResult.RemoveAll(item => sanitisedColumns.Contains(item.Text));
-            roslynResult.AddRange(columnItems);
-            return (roslynResult, false);
+            var linqItems = MapCompletionItems(roslynItems);
+            linqItems.RemoveAll(item => sanitisedColumns.Contains(item.Text));
+
+            var rowResult = new List<CompletionData>();
+            rowResult.AddRange(CompletionHelpers.BuildRowCompletions(metadata, false, rowTableName));
+            rowResult.AddRange(linqItems);
+            return (rowResult, false);
         }
 
         if (roslynItems.Count == 0)


### PR DESCRIPTION
## Summary
- Synthetic `Row` class now inherits `ExcelArray`, mirroring runtime — Roslyn can see the LINQ/`ExcelArray` surface (`Skip`, `Where`, `Map`, `FirstOrDefault`, ...).
- Completion provider augments Row completions with bracket-inserting column items instead of replacing them. Lambda-param shortcut removed so both code paths flow through Roslyn uniformly.
- Columns are listed first in the popup (`AvalonEdit` renders in insertion order — `Priority` is filter-only).

Closes #325

(Supersedes #327, which was closed when the branch was renamed.)

## Test plan
- [x] `dotnet build formula-boss/formula-boss.slnx` — 0 errors
- [x] `dotnet test formula-boss.Tests` — 596 passing
- [x] `dotnet test formula-boss.AddinTests` — 52 passing
- [x] New tests in `RoslynCompletionTests`:
  - `RowAfterFirst_AlsoShowsLinqAndExcelArrayMembers`
  - `RowLambdaParam_ShowsColumnsAndLinqMembers`
  - `Row_ColumnNamesNotDuplicated`
  - `Row_ColumnsListedBeforeLinqMembers`
- [x] New tests in `SyntheticDocumentBuilderTests`:
  - `Build_TypedRowClass_InheritsExcelArray`
  - `BuildForDiagnostics_LinqOnRow_CompilesWithoutDiagnostics`
  - `BuildForDiagnostics_ExcelArrayMethodsOnRow_CompilesWithoutDiagnostics`
- [x] Tim confirmed in the live add-in: Row IntelliSense now lists columns at top, LINQ members below

🤖 Generated with [Claude Code](https://claude.com/claude-code)