### PR TITLE
Remove producer/consumer coupling on synthetic Row column properties

### DIFF
--- a/formula-boss.Tests/RoslynCompletionTests.cs
+++ b/formula-boss.Tests/RoslynCompletionTests.cs
@@ -313,9 +313,9 @@ public class RoslynCompletionTests : IDisposable
     [Fact]
     public async Task Row_ColumnNamesNotDuplicated()
     {
-        // The synthetic Row class emits column-name properties for Roslyn; the bracket-
-        // syntax versions come from BuildRowCompletions. The merge must not list a
-        // column twice.
+        // Column names are surfaced only via BuildRowCompletions (as bracket-inserting
+        // items). Guards against a future regression that re-emits them as synthetic
+        // properties on Row, which would duplicate them in the merged list.
         var formula = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).`)";
         var textUp = "=LET(t, Sales, `t.Rows.First(r => r[\"Amount\"] > 100).";
 

--- a/formula-boss.Tests/SemanticAnalysisServiceTests.cs
+++ b/formula-boss.Tests/SemanticAnalysisServiceTests.cs
@@ -192,8 +192,10 @@ public class SemanticAnalysisServiceTests
     [Fact]
     public void FormatTypeForDisplay_ExcelScalar_UnchangedName()
     {
+        // Use the bracket indexer on Row to obtain ExcelScalar — column names are not
+        // emitted as dot-access properties on the synthetic Row.
         var display = _service.FormatTypeForDisplay(
-            GetTypeForExpression("Sales.Rows.First(r => true).Amount"),
+            GetTypeForExpression("Sales.Rows.First(r => true)[\"Amount\"]"),
             TwoTableMetadata);
         Assert.Equal("ExcelScalar", display);
     }

--- a/formula-boss.Tests/SyntheticDocumentBuilderTests.cs
+++ b/formula-boss.Tests/SyntheticDocumentBuilderTests.cs
@@ -30,13 +30,16 @@ public class SyntheticDocumentBuilderTests
     }
 
     [Fact]
-    public void Build_GeneratesTypedRowClass_WithColumnProperties()
+    public void Build_TypedRowClass_DoesNotEmitColumnNameProperties()
     {
+        // Column names are surfaced by CompletionHelpers.BuildRowCompletions as bracket-
+        // inserting items; emitting them as synthetic properties on Row would duplicate
+        // that path and force the completion provider to strip them out again.
         var (source, _) = SyntheticDocumentBuilder.Build("=`Sales.`", "=`Sales.", TwoTableMetadata);
         Assert.Contains("class __SalesRow", source);
-        Assert.Contains("public ExcelScalar Date", source);
-        Assert.Contains("public ExcelScalar Amount", source);
-        Assert.Contains("public ExcelScalar Region", source);
+        Assert.DoesNotContain("public ExcelScalar Date", source);
+        Assert.DoesNotContain("public ExcelScalar Amount", source);
+        Assert.DoesNotContain("public ExcelScalar Region", source);
     }
 
     [Fact]
@@ -106,23 +109,6 @@ public class SyntheticDocumentBuilderTests
         Assert.True(offset <= source.Length);
         // The character before the caret should be '.'
         Assert.Equal('.', source[offset - 1]);
-    }
-
-    [Fact]
-    public void Build_SanitisesColumnNamesWithSpaces()
-    {
-        var metadata = new WorkbookMetadata(
-            new[] { "Data" },
-            Array.Empty<string>(),
-            new Dictionary<string, IReadOnlyList<string>>
-            {
-                ["Data"] = new[] { "First Name", "Last Name", "Age" }
-            });
-
-        var (source, _) = SyntheticDocumentBuilder.Build("=`Data.`", "=`Data.", metadata);
-        Assert.Contains("public ExcelScalar FirstName", source);
-        Assert.Contains("public ExcelScalar LastName", source);
-        Assert.Contains("public ExcelScalar Age", source);
     }
 
     [Fact]

--- a/formula-boss.Tests/TypedDocumentBuilderTests.cs
+++ b/formula-boss.Tests/TypedDocumentBuilderTests.cs
@@ -84,19 +84,21 @@ public class TypedDocumentBuilderTests
     }
 
     [Fact]
-    public void EmitTableTypes_Row_HasColumnProperties()
+    public void EmitTableTypes_Row_HasIndexerAndColumnCount_ButNoColumnNameProperties()
     {
+        // Column names are surfaced by CompletionHelpers.BuildRowCompletions as bracket-
+        // inserting items, not as synthetic dot-access properties on the Row stub.
         var sb = new StringBuilder();
         TypedDocumentBuilder.AppendUsings(sb);
         TypedDocumentBuilder.EmitTableTypes(sb, SingleTableMetadata);
         var source = sb.ToString();
 
         Assert.Contains("class __SalesRow : ExcelArray {", source);
-        Assert.Contains("public ExcelScalar Date => default!;", source);
-        Assert.Contains("public ExcelScalar Amount => default!;", source);
-        Assert.Contains("public ExcelScalar Region => default!;", source);
         Assert.Contains("public ExcelScalar this[string columnName] => default!;", source);
         Assert.Contains("public int ColumnCount => 0;", source);
+        Assert.DoesNotContain("public ExcelScalar Date => default!;", source);
+        Assert.DoesNotContain("public ExcelScalar Amount => default!;", source);
+        Assert.DoesNotContain("public ExcelScalar Region => default!;", source);
     }
 
     [Fact]

--- a/formula-boss/Analysis/TypedDocumentBuilder.cs
+++ b/formula-boss/Analysis/TypedDocumentBuilder.cs
@@ -61,7 +61,7 @@ internal static class TypedDocumentBuilder
             return tableTypeNames;
         }
 
-        foreach (var (tableName, columns) in metadata.TableColumns)
+        foreach (var tableName in metadata.TableColumns.Keys)
         {
             var safeTableName = ColumnMapper.Sanitise(tableName);
             if (string.IsNullOrEmpty(safeTableName))
@@ -88,7 +88,7 @@ internal static class TypedDocumentBuilder
                 [typeof(Column)] = nameof(Column)
             };
 
-            EmitTypedRow(sb, rowTypeName, columns);
+            EmitTypedRow(sb, rowTypeName);
             EmitSyntheticCollection(sb, typeof(RowCollection), rowCollTypeName, typeMap, rowTypeName);
             EmitSyntheticCollection(sb, typeof(RowGroup), rowGroupTypeName, typeMap, rowTypeName);
             EmitSyntheticCollection(sb, typeof(GroupedRowCollection), groupedCollTypeName, typeMap,
@@ -101,22 +101,19 @@ internal static class TypedDocumentBuilder
         return tableTypeNames;
     }
 
-    private static void EmitTypedRow(StringBuilder sb, string rowTypeName, IReadOnlyList<string> columns)
+    private static void EmitTypedRow(StringBuilder sb, string rowTypeName)
     {
         // Inherit ExcelArray so synthetic Row exposes the same LINQ/ExcelArray surface
         // (Skip, Where, Map, FirstOrDefault, ...) as the runtime Row : ExcelArray type.
+        // Column names are surfaced separately by CompletionHelpers.BuildRowCompletions
+        // as bracket-inserting items, so they're deliberately not emitted as properties
+        // on the synthetic Row.
         sb.AppendLine($"class {rowTypeName} : ExcelArray {{");
         sb.AppendLine($"{rowTypeName}() : base(new object[0,0]) {{}}");
 
         // Row-specific members not present on ExcelArray
         sb.AppendLine("public ExcelScalar this[string columnName] => default!;");
         sb.AppendLine("public int ColumnCount => 0;");
-
-        var mapping = ColumnMapper.BuildMapping(columns.ToArray());
-        foreach (var (sanitised, _) in mapping)
-        {
-            sb.AppendLine($"public ExcelScalar {sanitised} => default!;");
-        }
 
         sb.AppendLine("}");
         sb.AppendLine();

--- a/formula-boss/UI/Completion/RoslynCompletionProvider.cs
+++ b/formula-boss/UI/Completion/RoslynCompletionProvider.cs
@@ -63,23 +63,14 @@ internal sealed class RoslynCompletionProvider
             ? await _workspace.GetTypeBeforeDotAsync(caretOffset, cancellationToken)
             : null;
 
-        // Check if the expression before the dot is a Row type — if so, augment Roslyn's
-        // completions (LINQ/ExcelArray surface) with bracket-inserting column completions.
-        // Filter the synthetic column-name properties from Roslyn so they don't duplicate
-        // the bracket-syntax versions emitted by BuildRowCompletions.
-        // Columns are listed first because they're the most common Row completion target —
-        // the AvalonEdit CompletionList renders items in insertion order.
+        // If the expression before the dot is a Row, augment Roslyn's completions with
+        // bracket-inserting column items. Run this before the empty-roslyn early return
+        // so column completions still appear when Roslyn produces nothing (e.g. lambda
+        // parameter syntax).
         var rowTableName = ResolveTableNameFromType(typeName, metadata, @"^__(.+)Row$");
         if (rowTableName != null)
         {
-            var sanitisedColumns = GetSanitisedColumnNames(rowTableName, metadata);
-            var linqItems = MapCompletionItems(roslynItems);
-            linqItems.RemoveAll(item => sanitisedColumns.Contains(item.Text));
-
-            var rowResult = new List<CompletionData>();
-            rowResult.AddRange(CompletionHelpers.BuildRowCompletions(metadata, false, rowTableName));
-            rowResult.AddRange(linqItems);
-            return (rowResult, false);
+            return (BuildAugmentedCompletions(roslynItems, rowTableName, metadata, columnsFirst: true), false);
         }
 
         if (roslynItems.Count == 0)
@@ -87,15 +78,10 @@ internal sealed class RoslynCompletionProvider
             return (Array.Empty<CompletionData>(), false);
         }
 
-        // Check if the expression before the dot is a Table type — if so,
-        // augment Roslyn's completions with bracket-inserting column completions
         var tableTableName = ResolveTableNameFromType(typeName, metadata, @"^__(.+)Table$");
         if (tableTableName != null)
         {
-            var roslynResult = MapCompletionItems(roslynItems);
-            var columnItems = CompletionHelpers.BuildRowCompletions(metadata, false, tableTableName);
-            roslynResult.AddRange(columnItems);
-            return (roslynResult, false);
+            return (BuildAugmentedCompletions(roslynItems, tableTableName, metadata, columnsFirst: false), false);
         }
 
         var result = MapCompletionItems(roslynItems);
@@ -103,23 +89,27 @@ internal sealed class RoslynCompletionProvider
     }
 
     /// <summary>
-    ///     Returns the set of sanitised column-name property identifiers emitted on the
-    ///     synthetic Row class for a given table. Used to strip these synthetic stubs
-    ///     from Roslyn's completion list so they don't duplicate the bracket-syntax
-    ///     column completions.
+    ///     Combines Roslyn's completion items with bracket-inserting column completions for the
+    ///     given table. Columns appear first (Row) or last (Table) per <paramref name="columnsFirst" />,
+    ///     matching how the AvalonEdit CompletionList renders items in insertion order.
     /// </summary>
-    private static HashSet<string> GetSanitisedColumnNames(string tableName, WorkbookMetadata? metadata)
+    private static IReadOnlyList<CompletionData> BuildAugmentedCompletions(
+        IReadOnlyList<CompletionItem> roslynItems, string tableName, WorkbookMetadata? metadata,
+        bool columnsFirst)
     {
-        var result = new HashSet<string>(StringComparer.Ordinal);
-        if (metadata == null ||
-            !metadata.TableColumns.TryGetValue(tableName, out var columns))
-        {
-            return result;
-        }
+        var memberItems = MapCompletionItems(roslynItems);
+        var columnItems = CompletionHelpers.BuildRowCompletions(metadata, false, tableName);
 
-        foreach (var (sanitised, _) in ColumnMapper.BuildMapping(columns.ToArray()))
+        var result = new List<CompletionData>(memberItems.Count + columnItems.Count);
+        if (columnsFirst)
         {
-            result.Add(sanitised);
+            result.AddRange(columnItems);
+            result.AddRange(memberItems);
+        }
+        else
+        {
+            result.AddRange(memberItems);
+            result.AddRange(columnItems);
         }
 
         return result;


### PR DESCRIPTION
## Summary
- Drop synthetic column-name property emission on `__<Table>Row` (`TypedDocumentBuilder.EmitTypedRow`) — column names are surfaced exclusively via `CompletionHelpers.BuildRowCompletions` as bracket-inserting items.
- Drop the matching `GetSanitisedColumnNames` strip path in `RoslynCompletionProvider`; without the synthetic properties, Roslyn never emits column names for Row dot-access, so no de-duplication is needed.
- Extract `BuildAugmentedCompletions(roslynItems, tableName, columnsFirst)` so the Row and Table branches share one assembly path. Row passes `columnsFirst: true`, Table passes `columnsFirst: false` (preserves PR #329 ordering on both sides).
- Invert the synthetic-column-property assertions in `SyntheticDocumentBuilderTests` and `TypedDocumentBuilderTests` to assert their absence; rewrite `SemanticAnalysisServiceTests.FormatTypeForDisplay_ExcelScalar_UnchangedName` to use bracket access (`r["Amount"]`) for its `ExcelScalar` lookup, since the dot-access property no longer exists.

User-facing behaviour is unchanged — Row dot-completion still lists columns first then LINQ/`ExcelArray` members; Table dot-completion still lists Roslyn members first then columns.

Closes #330

## Test plan
- [x] `dotnet test formula-boss.Tests` — 595 passed
- [x] `dotnet test formula-boss.AddinTests` — 52 passed
- [x] Tim spot-checks the live editor: `row.` lists columns first then LINQ surface; `table.` lists Roslyn members then columns; both still tab-complete to bracket syntax for column names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)